### PR TITLE
fix: allow SDK versions 0.5+

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Sample `.csproj` file:
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageId>OpenFeature.MyComponent</PackageId>
+    <PackageId>OpenFeature.Contrib.MyComponent</PackageId>
     <VersionNumber>0.0.1</VersionNumber> <!--x-release-please-version -->
     <Version>$(VersionNumber)</Version>
     <AssemblyVersion>$(VersionNumber)</AssemblyVersion>

--- a/build/Common.props
+++ b/build/Common.props
@@ -24,6 +24,7 @@
       Refer to https://docs.microsoft.com/nuget/concepts/package-versioning for semver syntax.
     -->
     <MicrosoftSourceLinkGitHubPkgVer>[1.0.0,2.0)</MicrosoftSourceLinkGitHubPkgVer>
-    <OpenFeatureVer>[0.5,0.6)</OpenFeatureVer>
+    <!-- 0.5+ -->
+    <OpenFeatureVer>[0.5,)</OpenFeatureVer>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Not REALLY a fix: in preparation for 1.0, this permits SDK versions higher than `0.5.0+`, instead of just `0.5.0 - 0.6.0`.