### PR TITLE
fix:  GoFeatureFlagUser class was not serialized.

### DIFF
--- a/src/OpenFeature.Contrib.Providers.GOFeatureFlag/GoFeatureFlagProvider.cs
+++ b/src/OpenFeature.Contrib.Providers.GOFeatureFlag/GoFeatureFlagProvider.cs
@@ -244,10 +244,9 @@ namespace OpenFeature.Contrib.Providers.GOFeatureFlag
         private async Task<GoFeatureFlagResponse> CallApi<T>(string flagKey, T defaultValue,
             EvaluationContext context = null)
         {
-            var user = GoFeatureFlagUser.FromEvaluationContext(context);
             var request = new GOFeatureFlagRequest<T>
             {
-                User = user,
+                User = context,
                 DefaultValue = defaultValue
             };
             var goffRequest = JsonSerializer.Serialize(request, _serializerOptions);

--- a/src/OpenFeature.Contrib.Providers.GOFeatureFlag/GoFeatureFlagUser.cs
+++ b/src/OpenFeature.Contrib.Providers.GOFeatureFlag/GoFeatureFlagUser.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+
 using OpenFeature.Contrib.Providers.GOFeatureFlag.exception;
 using OpenFeature.Model;
 
@@ -12,7 +13,7 @@ namespace OpenFeature.Contrib.Providers.GOFeatureFlag
     {
         private const string AnonymousField = "anonymous";
         private const string KeyField = "targetingKey";
-     
+
         /// <summary>
         ///   The targeting key for the user.
         /// </summary>

--- a/src/OpenFeature.Contrib.Providers.GOFeatureFlag/GoFeatureFlagUser.cs
+++ b/src/OpenFeature.Contrib.Providers.GOFeatureFlag/GoFeatureFlagUser.cs
@@ -12,14 +12,26 @@ namespace OpenFeature.Contrib.Providers.GOFeatureFlag
     {
         private const string AnonymousField = "anonymous";
         private const string KeyField = "targetingKey";
-        private string Key { get; set; }
-        private bool Anonymous { get; set; }
-        private Dictionary<string, object> Custom { get; set; }
+     
+        /// <summary>
+        ///   The targeting key for the user.
+        /// </summary>
+        public string Key { get; private set; }
+
+        /// <summary>
+        ///   Is the user Anonymous.
+        /// </summary>
+        public bool Anonymous { get; private set; }
+
+        /// <summary>
+        ///   Additional Custom Data to pass to GO Feature Flag.
+        /// </summary>
+        public Dictionary<string, object> Custom { get; private set; }
 
         /**
-         * FromEvaluationContext convert the evaluation context into a GOFeatureFlagUser Object.
+         * Convert the evaluation context into a GOFeatureFlagUser Object.
          */
-        public static GoFeatureFlagUser FromEvaluationContext(EvaluationContext ctx)
+        public static implicit operator GoFeatureFlagUser(EvaluationContext ctx)
         {
             try
             {

--- a/src/OpenFeature.Contrib.Providers.GOFeatureFlag/README.md
+++ b/src/OpenFeature.Contrib.Providers.GOFeatureFlag/README.md
@@ -15,32 +15,32 @@ The first things we will do is install the **Open Feature SDK** and the **GO Fea
 
 ### .NET Cli
 ```shell
-dotnet add package OpenFeature.Contrib.Providers.GOFeatureFlag
+dotnet add package OpenFeature.Contrib.GOFeatureFlag
 ```
 ### Package Manager
 
 ```shell
-NuGet\Install-Package OpenFeature.Contrib.Providers.GOFeatureFlag
+NuGet\Install-Package OpenFeature.Contrib.GOFeatureFlag
 ```
 ### Package Reference
 
 ```xml
-<PackageReference Include="OpenFeature.Contrib.Providers.GOFeatureFlag" />
+<PackageReference Include="OpenFeature.Contrib.GOFeatureFlag" />
 ```
 ### Packet cli
 
 ```shell
-paket add OpenFeature.Contrib.Providers.GOFeatureFlag
+paket add OpenFeature.Contrib.GOFeatureFlag
 ```
 
 ### Cake
 
 ```shell
-// Install OpenFeature.Contrib.Providers.GOFeatureFlag as a Cake Addin
-#addin nuget:?package=OpenFeature.Contrib.Providers.GOFeatureFlag
+// Install OpenFeature.Contrib.GOFeatureFlag as a Cake Addin
+#addin nuget:?package=OpenFeature.Contrib.GOFeatureFlag
 
-// Install OpenFeature.Contrib.Providers.GOFeatureFlag as a Cake Tool
-#tool nuget:?package=OpenFeature.Contrib.Providers.GOFeatureFlag
+// Install OpenFeature.Contrib.GOFeatureFlag as a Cake Tool
+#tool nuget:?package=OpenFeature.Contrib.GOFeatureFlag
 ```
 
 ## Initialize your Open Feature client

--- a/test/OpenFeature.Contrib.Providers.GOFeatureFlag.Test/GoFeatureFlagUserTest.cs
+++ b/test/OpenFeature.Contrib.Providers.GOFeatureFlag.Test/GoFeatureFlagUserTest.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
+
 using OpenFeature.Model;
+
 using Xunit;
 
 namespace OpenFeature.Contrib.Providers.GOFeatureFlag.Test;
@@ -10,13 +12,13 @@ public class GoFeatureFlagUserTest
     public void GoFeatureFlagUserSerializesCorrectly()
     {
         var userContext = EvaluationContext.Builder()
-            .Set("targetingKey", "1d1b9238-2591-4a47-94cf-d2bc080892f1") 
+            .Set("targetingKey", "1d1b9238-2591-4a47-94cf-d2bc080892f1")
             .Set("firstname", "john")
             .Set("lastname", "doe")
             .Set("email", "john.doe@gofeatureflag.org")
-            .Set("admin", true) 
+            .Set("admin", true)
             .Set("anonymous", false)
-            .Build();        
+            .Build();
 
         GoFeatureFlagUser user = userContext;
 

--- a/test/OpenFeature.Contrib.Providers.GOFeatureFlag.Test/GoFeatureFlagUserTest.cs
+++ b/test/OpenFeature.Contrib.Providers.GOFeatureFlag.Test/GoFeatureFlagUserTest.cs
@@ -1,0 +1,27 @@
+using System.Text.Json;
+using OpenFeature.Model;
+using Xunit;
+
+namespace OpenFeature.Contrib.Providers.GOFeatureFlag.Test;
+
+public class GoFeatureFlagUserTest
+{
+    [Fact]
+    public void GoFeatureFlagUserSerializesCorrectly()
+    {
+        var userContext = EvaluationContext.Builder()
+            .Set("targetingKey", "1d1b9238-2591-4a47-94cf-d2bc080892f1") 
+            .Set("firstname", "john")
+            .Set("lastname", "doe")
+            .Set("email", "john.doe@gofeatureflag.org")
+            .Set("admin", true) 
+            .Set("anonymous", false)
+            .Build();        
+
+        GoFeatureFlagUser user = userContext;
+
+        var userAsString = JsonSerializer.Serialize(user, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+
+        Assert.Contains("{\"key\":\"1d1b9238-2591-4a47-94cf-d2bc080892f1\",\"anonymous\":false,\"custom\":{", userAsString);
+    }
+}


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- fixes an issue

`System.Text.Json` does not serialize private members of a class. Since the class `GoFeatureFlagUser` had the following private members:
```
        private string Key { get; set; }
        private bool Anonymous { get; set; }
        private Dictionary<string, object> Custom { get; set; }
```
When it was serialized as the User in `GOFeatureFlagRequest`, the Json that was returned was `{ "user": {},  ...` instead of `{ "user": { "key: :  ...`

This commit fixes this issue by making the property public and adding a test.

- updates documents

The name of the package was wrong it should be ***OpenFeature.Contrib.GOFeatureFla**g* and not *OpenFeature.Contrib.Providers.GOFeatureFlag*

![image](https://user-images.githubusercontent.com/2294035/216357889-0497adbc-387b-46df-bf6f-0306d15d32f7.png)


### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->



### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

