### PR TITLE
feat: unix socket support for flagd provider

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        version: [net6.0]
+        version: [net6.0,net7.0]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        version: [net462,net6.0]
+        version: [net462,net6.0,net7.0]
 
     steps:
     - uses: actions/checkout@v3

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net5.0;net6.0;net7.0</TargetFrameworks>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/open-feature/dotnet-sdk</RepositoryUrl>
     <Description>OpenFeature is an open standard for feature flag management, created to support a robust feature flag ecosystem using cloud native technologies. OpenFeature will provide a unified API and SDK, and a developer-first, cloud-native implementation, with extensibility for open source and commercial offerings.</Description>

--- a/src/OpenFeature.Contrib.Providers.Flagd/FlagdProvider.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/FlagdProvider.cs
@@ -28,9 +28,10 @@ namespace OpenFeature.Contrib.Providers.Flagd
         /// <summary>
         ///     Constructor of the provider. This constructor uses the value of the following
         ///     environment variables to initialise its client:
-        ///     FLAGD_HOST - The host name of the flagd server (default="localhost")
-        ///     FLAGD_PORT - The port of the flagd server (default="8013")
-        ///     FLAGD_TLS  - Determines whether to use https or not (default="false")
+        ///     FLAGD_HOST         - The host name of the flagd server (default="localhost")
+        ///     FLAGD_PORT         - The port of the flagd server (default="8013")
+        ///     FLAGD_TLS          - Determines whether to use https or not (default="false")
+        ///     FLAGD_SOCKET_PATH - Path to the unix socket (default="")
         /// </summary>
         public FlagdProvider()
         {
@@ -405,6 +406,8 @@ namespace OpenFeature.Contrib.Providers.Flagd
                 ConnectCallback = connectionFactory.ConnectAsync
             };
             
+            // point to localhost and let the custom ConnectCallback handle the communication over the unix socket
+            // see https://learn.microsoft.com/en-us/aspnet/core/grpc/interprocess-uds?view=aspnetcore-7.0 for more details
             return new Service.ServiceClient(GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions
             {
                 HttpHandler = socketsHttpHandler

--- a/src/OpenFeature.Contrib.Providers.Flagd/FlagdProvider.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/FlagdProvider.cs
@@ -388,7 +388,7 @@ namespace OpenFeature.Contrib.Providers.Flagd
         {
             var useUnixSocket = url.ToString().StartsWith("unix://");
 
-            if (!useUnixSocket) 
+            if (!useUnixSocket)
             {
 #if NET462
                  return new Service.ServiceClient(GrpcChannel.ForAddress(url, new GrpcChannelOptions
@@ -399,7 +399,7 @@ namespace OpenFeature.Contrib.Providers.Flagd
                 return new Service.ServiceClient(GrpcChannel.ForAddress(url));
 #endif
             }
-           
+
 #if NET5_0_OR_GREATER
             var udsEndPoint = new UnixDomainSocketEndPoint(url.ToString().Substring("unix://".Length));
             var connectionFactory = new UnixDomainSocketConnectionFactory(udsEndPoint);

--- a/src/OpenFeature.Contrib.Providers.Flagd/FlagdProvider.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/FlagdProvider.cs
@@ -386,7 +386,7 @@ namespace OpenFeature.Contrib.Providers.Flagd
 
         private static Service.ServiceClient buildClientForPlatform(Uri url)
         {
-            var useUnixSocket = url.ToString().StartsWith("unix://"); 
+            var useUnixSocket = url.ToString().StartsWith("unix://");
 #if NET462
             if (useUnixSocket) {
                 // unix socket support is not available in this dotnet version
@@ -413,7 +413,8 @@ namespace OpenFeature.Contrib.Providers.Flagd
                 HttpHandler = socketsHttpHandler
             }));
 #else
-            if (useUnixSocket) {
+            if (useUnixSocket)
+            {
                 // unix socket support is not available in this dotnet version
                 throw new Exception("unix sockets are not supported in this version.");
             }

--- a/src/OpenFeature.Contrib.Providers.Flagd/README.md
+++ b/src/OpenFeature.Contrib.Providers.Flagd/README.md
@@ -76,21 +76,29 @@ namespace OpenFeatureTestApp
 
 The URI of the flagd server to which the `flagd Provider` connects to can either be passed directly to the constructor, or be configured using the following environment variables:
 
-| Option name           | Environment variable name       | Type    | Default   | Values        |
-| --------------------- | ------------------------------- | ------- | --------- | ------------- |
-| host                  | FLAGD_HOST                      | string  | localhost |               |
-| port                  | FLAGD_PORT                      | number  | 8013      |               |
-| tls                   | FLAGD_TLS                       | boolean | false     |               |
+| Option name      | Environment variable name      | Type    | Default   | Values        |
+|------------------|--------------------------------|---------|-----------| ------------- |
+| host             | FLAGD_HOST                     | string  | localhost |               |
+| port             | FLAGD_PORT                     | number  | 8013      |               |
+| tls              | FLAGD_TLS                      | boolean | false     |               |
+| unix socket path | FLAGD_SOCKET_PATH              | string  |           |               |
 
-So for example, if you would like to pass the URI directly, you can initialise it as follows:
+Note that if `FLAGD_SOCKET_PATH` is set, this value takes precedence, and the other variables (`FLAGD_HOST`, `FLAGD_PORT`, `FLAGD_TLS`) are disregarded.
 
-```csharp
-var flagdProvider = new FlagdProvider(new Uri("http://localhost:8013"));
-```
 
-Or, if you rely on the environment variables listed above, you can use the empty costructor:
-
+If you rely on the environment variables listed above, you can use the empty constructor which then configures the provider accordingly:
 
 ```csharp
 var flagdProvider = new FlagdProvider();
 ```
+
+Alternatively, if you would like to pass the URI directly, you can initialise it as follows:
+
+```csharp
+// either communicate with Flagd over HTTP ...
+var flagdProvider = new FlagdProvider(new Uri("http://localhost:8013"));
+
+// ... or use the unix:// prefix if the provider should communicate via a unix socket
+var unixFlagdProvider = new FlagdProvider(new Uri("unix://socket.tmp"));  
+```
+

--- a/src/OpenFeature.Contrib.Providers.Flagd/UnixDomainSocketConnectionFactory.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/UnixDomainSocketConnectionFactory.cs
@@ -1,0 +1,38 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OpenFeature.Contrib.Providers.Flagd
+{
+    public class UnixDomainSocketConnectionFactory
+    {
+        private readonly EndPoint _endPoint;
+
+        public UnixDomainSocketConnectionFactory(EndPoint endPoint)
+        {
+            _endPoint = endPoint;
+        }
+        
+#if NET5_0_OR_GREATER
+        public async ValueTask<Stream> ConnectAsync(SocketsHttpConnectionContext _, CancellationToken cancellationToken = default)
+        {
+            var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+
+            try
+            {
+                await socket.ConnectAsync(_endPoint, cancellationToken).ConfigureAwait(false);
+                return new NetworkStream(socket, true);
+            }
+            catch (Exception ex)
+            {
+                socket.Dispose();
+                throw new HttpRequestException($"Error connecting to '{_endPoint}'.", ex);
+            }
+        }
+#endif
+    }
+}

--- a/src/OpenFeature.Contrib.Providers.Flagd/UnixDomainSocketConnectionFactory.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/UnixDomainSocketConnectionFactory.cs
@@ -17,15 +17,16 @@ namespace OpenFeature.Contrib.Providers.Flagd
         ///     Constructor of the connection factory
         ///     <param name="endpoint">The path to the unix socket</param>
         /// </summary>
-        public UnixDomainSocketConnectionFactory(EndPoint endPoint)
+        public UnixDomainSocketConnectionFactory(EndPoint endpoint)
         {
-            _endPoint = endPoint;
+            _endPoint = endpoint;
         }
 
 #if NET5_0_OR_GREATER
         /// <summary>   
         ///     ConnectAsync is a custom implementation of the ConnectAsync method used by the grpc client
         /// </summary>
+        /// <param name="_">unused - SocketsHttpConnectionContext</param>
         /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>A ValueTask object representing the given</returns>
         public async ValueTask<Stream> ConnectAsync(SocketsHttpConnectionContext _, CancellationToken cancellationToken = default)

--- a/src/OpenFeature.Contrib.Providers.Flagd/UnixDomainSocketConnectionFactory.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/UnixDomainSocketConnectionFactory.cs
@@ -8,16 +8,26 @@ using System.Threading.Tasks;
 
 namespace OpenFeature.Contrib.Providers.Flagd
 {
+    /// <inheritdoc/>
     public class UnixDomainSocketConnectionFactory
     {
         private readonly EndPoint _endPoint;
 
+        /// <summary>
+        ///     Constructor of the connection factory
+        ///     <param name="endpoint">The path to the unix socket</param>
+        /// </summary>
         public UnixDomainSocketConnectionFactory(EndPoint endPoint)
         {
             _endPoint = endPoint;
         }
-        
+
 #if NET5_0_OR_GREATER
+        /// <summary>   
+        ///     ConnectAsync is a custom implementation of the ConnectAsync method used by the grpc client
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <returns>A ValueTask object representing the given</returns>
         public async ValueTask<Stream> ConnectAsync(SocketsHttpConnectionContext _, CancellationToken cancellationToken = default)
         {
             var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);


### PR DESCRIPTION
Closes #35 

As discussed in the issue, I have added net5.0 and above to the TargetFrameworks and used preprocessor directives to only make use of the unix socket support in compatible dotnet frameworks (net5.0 and above).