### PR TITLE
fix: some issues in the GO Feature Flag relay proxy

### DIFF
--- a/src/OpenFeature.Contrib.Providers.GOFeatureFlag/GoFeatureFlagProvider.cs
+++ b/src/OpenFeature.Contrib.Providers.GOFeatureFlag/GoFeatureFlagProvider.cs
@@ -181,7 +181,7 @@ namespace OpenFeature.Contrib.Providers.GOFeatureFlag
             try
             {
                 var resp = await CallApi(flagKey, defaultValue, context);
-                return new ResolutionDetails<double>(flagKey, double.Parse(resp.value.ToString()), ErrorType.None,
+                return new ResolutionDetails<double>(flagKey, double.Parse(resp.value.ToString(), System.Globalization.CultureInfo.InvariantCulture), ErrorType.None,
                     resp.reason, resp.variationType);
             }
             catch (FormatException e)

--- a/src/OpenFeature.Contrib.Providers.GOFeatureFlag/GoFeatureFlagProvider.cs
+++ b/src/OpenFeature.Contrib.Providers.GOFeatureFlag/GoFeatureFlagProvider.cs
@@ -267,7 +267,7 @@ namespace OpenFeature.Contrib.Providers.GOFeatureFlag
             if (goffResp != null && Reason.Disabled.Equals(goffResp.reason))
                 throw new FlagDisabled();
 
-            if (ErrorType.FlagNotFound.ToString().Equals(goffResp.errorCode))
+            if ("FLAG_NOT_FOUND".Equals(goffResp.errorCode))
                 throw new FlagNotFoundError($"flag {flagKey} was not found in your configuration");
 
             return goffResp;

--- a/test/OpenFeature.Contrib.Providers.GOFeatureFlag.Test/GoFeatureFlagProviderTest.cs
+++ b/test/OpenFeature.Contrib.Providers.GOFeatureFlag.Test/GoFeatureFlagProviderTest.cs
@@ -501,7 +501,7 @@ public class GoFeatureFlagProviderTest
         Assert.Equal(Reason.TargetingMatch, res.Result.Reason);
         Assert.Equal("True", res.Result.Variant);
     }
-    
+
     [Fact]
     private void should_use_object_default_value_if_flag_not_found()
     {


### PR DESCRIPTION
## This PR
- Fix the issue with when flag is not found, the comparison was not working.
- Fix an issue when double are not recognized.
