### PR TITLE
feat: implemented LRU caching for flagd provider 

### DIFF
--- a/src/OpenFeature.Contrib.Providers.Flagd/Cache.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/Cache.cs
@@ -1,8 +1,11 @@
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 
 namespace OpenFeature.Contrib.Providers.Flagd
 {
-    interface ICache<TKey, TValue>
+    internal interface ICache<TKey, TValue>
     {
         void Add(TKey key, TValue value);
         TValue TryGet(TKey key);

--- a/src/OpenFeature.Contrib.Providers.Flagd/Cache.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/Cache.cs
@@ -1,0 +1,111 @@
+using System.Collections.Generic;
+
+namespace OpenFeature.Contrib.Providers.Flagd
+{
+    interface ICache<TKey, TValue>
+    {
+        void Add(TKey key, TValue value);
+        TValue TryGet(TKey key);
+        void Delete(TKey key);
+    }
+    class LRUCache<TKey, TValue> : ICache<TKey, TValue> where TValue : class
+    {
+        private readonly int _capacity;
+        private readonly Dictionary<TKey, Node> _map;
+        private Node _head;
+        private Node _tail;
+
+        public LRUCache(int capacity)
+        {
+            _capacity = capacity;
+            _map = new Dictionary<TKey, Node>();
+        }
+
+        public TValue TryGet(TKey key)
+        {
+            System.Console.WriteLine("looking for " + key.ToString());
+            if (_map.TryGetValue(key, out Node node))
+            {
+                System.Console.WriteLine("found: " + key.ToString() + " with value: " + node.ToString());
+                MoveToFront(node);
+                return node.Value;
+            }
+            return default(TValue);
+        }
+
+        public void Add(TKey key, TValue value)
+        {
+            if (_map.TryGetValue(key, out Node node))
+            {
+                node.Value = value;
+                MoveToFront(node);
+            }
+            else
+            {
+                if (_map.Count == _capacity)
+                {
+                    _map.Remove(_tail.Key);
+                    RemoveTail();
+                }
+                node = new Node(key, value);
+                _map.Add(key, node);
+                AddToFront(node);
+            }
+        }
+
+        private void MoveToFront(Node node)
+        {
+            if (node == _head)
+                return;
+            node.Prev.Next = node.Next;
+            if (node == _tail)
+                _tail = node.Prev;
+            else
+                node.Next.Prev = node.Prev;
+            AddToFront(node);
+        }
+
+        private void AddToFront(Node node)
+        {
+            if (_head == null)
+            {
+                _head = node;
+                _tail = node;
+                return;
+            }
+            node.Next = _head;
+            _head.Prev = node;
+            _head = node;
+        }
+
+        private void RemoveTail()
+        {
+            _tail = _tail.Prev;
+            if (_tail != null)
+                _tail.Next = null;
+            else
+                _head = null;
+        }
+
+        public void Delete(TKey key)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        private class Node
+        {
+            public TKey Key;
+            public TValue Value;
+            public Node Next;
+            public Node Prev;
+
+            public Node(TKey key, TValue value)
+            {
+                Key = key;
+                Value = value;
+            }
+        }
+    }
+
+}
+

--- a/src/OpenFeature.Contrib.Providers.Flagd/Cache.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/Cache.cs
@@ -44,7 +44,7 @@ namespace OpenFeature.Contrib.Providers.Flagd
             {
                 _mtx.ReleaseMutex();
             }
-            
+
         }
 
         public void Add(TKey key, TValue value)
@@ -73,7 +73,7 @@ namespace OpenFeature.Contrib.Providers.Flagd
             {
                 _mtx.ReleaseMutex();
             }
-            
+
         }
 
         public void Delete(TKey key)
@@ -86,8 +86,8 @@ namespace OpenFeature.Contrib.Providers.Flagd
                     if (node == _head)
                     {
                         _head = node.Next;
-                    } 
-                    else 
+                    }
+                    else
                     {
                         node.Prev.Next = node.Next;
                     }

--- a/src/OpenFeature.Contrib.Providers.Flagd/Cache.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/Cache.cs
@@ -53,6 +53,26 @@ namespace OpenFeature.Contrib.Providers.Flagd
             }
         }
 
+        public void Delete(TKey key)
+        {
+            if (_map.TryGetValue(key, out Node node))
+            {
+                if (node == _head)
+                {
+                    _head = node.Next;
+                } 
+                else 
+                {
+                    node.Prev.Next = node.Next;
+                }
+                if (node.Next != null)
+                {
+                    node.Next.Prev = node.Prev;
+                }
+                _map.Remove(key);
+            }
+        }
+
         private void MoveToFront(Node node)
         {
             if (node == _head)
@@ -85,11 +105,6 @@ namespace OpenFeature.Contrib.Providers.Flagd
                 _tail.Next = null;
             else
                 _head = null;
-        }
-
-        public void Delete(TKey key)
-        {
-            throw new System.NotImplementedException();
         }
 
         private class Node

--- a/src/OpenFeature.Contrib.Providers.Flagd/Cache.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/Cache.cs
@@ -54,7 +54,7 @@ namespace OpenFeature.Contrib.Providers.Flagd
                 }
                 else
                 {
-                    if (_map.Count == _capacity)
+                    if (_map.Count >= _capacity)
                     {
                         _map.Remove(_tail.Key);
                         RemoveTail();
@@ -151,7 +151,7 @@ namespace OpenFeature.Contrib.Providers.Flagd
         {
 
             public System.Threading.Mutex _mtx;
-            
+
             public Mutex(ref System.Threading.Mutex mtx)
             {
                 _mtx = mtx;

--- a/src/OpenFeature.Contrib.Providers.Flagd/FlagdConfig.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/FlagdConfig.cs
@@ -1,0 +1,69 @@
+using System;
+
+namespace OpenFeature.Contrib.Providers.Flagd
+
+{
+    public class FlagdConfig
+    {
+        public string Host
+        {
+            get { return _host; }
+        }
+
+        public bool CacheEnabled
+        {
+            get { return _cache; }
+        }
+
+        public int MaxCacheSize
+        {
+            get { return _maxCacheSize; }
+        }
+
+        private readonly string _host;
+        private readonly string _port;
+        private readonly bool _useTLS;
+        private readonly string _socketPath;
+        private readonly bool _cache;
+        private readonly int _maxCacheSize;
+        private readonly int _maxEventStreamRetries;
+
+        public FlagdConfig()
+        {
+            _host = Environment.GetEnvironmentVariable("FLAGD_HOST") ?? "localhost";
+            _port = Environment.GetEnvironmentVariable("FLAGD_PORT") ?? "8013";
+            _useTLS = bool.Parse(Environment.GetEnvironmentVariable("FLAGD_TLS") ?? "false");
+            _socketPath = Environment.GetEnvironmentVariable("FLAGD_SOCKET_PATH") ?? "";
+            var cacheStr = Environment.GetEnvironmentVariable("FLAGD_CACHE") ?? "";
+
+            if (cacheStr.ToUpper().Equals("LRU"))
+            {
+                _cache = true;
+                _maxCacheSize = int.Parse(Environment.GetEnvironmentVariable("FLAGD_MAX_CACHE_SIZE") ?? "10");
+                _maxEventStreamRetries = int.Parse(Environment.GetEnvironmentVariable("FLAGD_MAX_EVENT_STREAM_RETRIES") ?? "3");
+            }
+        }
+
+        public Uri GetUri()
+        {
+            Uri uri;
+            if (_socketPath != "")
+            {
+                uri = new Uri("unix://" + _socketPath);
+            }
+            else
+            {
+                var protocol = "http";
+
+                if (_useTLS)
+                {
+                    protocol = "https";
+                }
+
+                uri = new Uri(protocol + "://" + _host + ":" + _port);
+            }
+            return uri;
+        }
+
+    }
+}

--- a/src/OpenFeature.Contrib.Providers.Flagd/FlagdConfig.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/FlagdConfig.cs
@@ -5,6 +5,7 @@ namespace OpenFeature.Contrib.Providers.Flagd
 {
     internal class FlagdConfig
     {
+        internal static int CacheSizeDefault = 10;
         internal string Host
         {
             get { return _host; }
@@ -39,7 +40,7 @@ namespace OpenFeature.Contrib.Providers.Flagd
             if (cacheStr.ToUpper().Equals("LRU"))
             {
                 _cache = true;
-                _maxCacheSize = int.Parse(Environment.GetEnvironmentVariable("FLAGD_MAX_CACHE_SIZE") ?? "10");
+                _maxCacheSize = int.Parse(Environment.GetEnvironmentVariable("FLAGD_MAX_CACHE_SIZE") ?? $"{CacheSizeDefault}");
                 _maxEventStreamRetries = int.Parse(Environment.GetEnvironmentVariable("FLAGD_MAX_EVENT_STREAM_RETRIES") ?? "3");
             }
         }

--- a/src/OpenFeature.Contrib.Providers.Flagd/FlagdConfig.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/FlagdConfig.cs
@@ -3,19 +3,19 @@ using System;
 namespace OpenFeature.Contrib.Providers.Flagd
 
 {
-    public class FlagdConfig
+    internal class FlagdConfig
     {
-        public string Host
+        internal string Host
         {
             get { return _host; }
         }
 
-        public bool CacheEnabled
+        internal bool CacheEnabled
         {
             get { return _cache; }
         }
 
-        public int MaxCacheSize
+        internal int MaxCacheSize
         {
             get { return _maxCacheSize; }
         }
@@ -28,7 +28,7 @@ namespace OpenFeature.Contrib.Providers.Flagd
         private readonly int _maxCacheSize;
         private readonly int _maxEventStreamRetries;
 
-        public FlagdConfig()
+        internal FlagdConfig()
         {
             _host = Environment.GetEnvironmentVariable("FLAGD_HOST") ?? "localhost";
             _port = Environment.GetEnvironmentVariable("FLAGD_PORT") ?? "8013";
@@ -44,7 +44,7 @@ namespace OpenFeature.Contrib.Providers.Flagd
             }
         }
 
-        public Uri GetUri()
+        internal Uri GetUri()
         {
             Uri uri;
             if (_socketPath != "")
@@ -64,6 +64,5 @@ namespace OpenFeature.Contrib.Providers.Flagd
             }
             return uri;
         }
-
     }
 }

--- a/src/OpenFeature.Contrib.Providers.Flagd/FlagdConfig.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/FlagdConfig.cs
@@ -14,6 +14,7 @@ namespace OpenFeature.Contrib.Providers.Flagd
         internal bool CacheEnabled
         {
             get { return _cache; }
+            set { _cache = value; }
         }
 
         internal int MaxCacheSize
@@ -24,15 +25,16 @@ namespace OpenFeature.Contrib.Providers.Flagd
         internal int MaxEventStreamRetries
         {
             get { return _maxEventStreamRetries; }
+            set { _maxEventStreamRetries = value; }
         }
 
-        private readonly string _host;
-        private readonly string _port;
-        private readonly bool _useTLS;
-        private readonly string _socketPath;
-        private readonly bool _cache;
-        private readonly int _maxCacheSize;
-        private readonly int _maxEventStreamRetries;
+        private string _host;
+        private string _port;
+        private bool _useTLS;
+        private string _socketPath;
+        private bool _cache;
+        private int _maxCacheSize;
+        private int _maxEventStreamRetries;
 
         internal FlagdConfig()
         {

--- a/src/OpenFeature.Contrib.Providers.Flagd/FlagdConfig.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/FlagdConfig.cs
@@ -5,6 +5,13 @@ namespace OpenFeature.Contrib.Providers.Flagd
 {
     internal class FlagdConfig
     {
+        internal const string EnvVarHost = "FLAGD_HOST";
+        internal const string EnvVarPort = "FLAGD_PORT";
+        internal const string EnvVarTLS = "FLAGD_TLS";
+        internal const string EnvVarSocketPath = "FLAGD_SOCKET_PATH";
+        internal const string EnvVarCache = "FLAGD_CACHE";
+        internal const string EnvVarMaxCacheSize = "FLAGD_MAX_CACHE_SIZE";
+        internal const string EnvVarMaxEventStreamRetries = "FLAGD_MAX_EVENT_STREAM_RETRIES";
         internal static int CacheSizeDefault = 10;
         internal string Host
         {
@@ -38,17 +45,17 @@ namespace OpenFeature.Contrib.Providers.Flagd
 
         internal FlagdConfig()
         {
-            _host = Environment.GetEnvironmentVariable("FLAGD_HOST") ?? "localhost";
-            _port = Environment.GetEnvironmentVariable("FLAGD_PORT") ?? "8013";
-            _useTLS = bool.Parse(Environment.GetEnvironmentVariable("FLAGD_TLS") ?? "false");
-            _socketPath = Environment.GetEnvironmentVariable("FLAGD_SOCKET_PATH") ?? "";
-            var cacheStr = Environment.GetEnvironmentVariable("FLAGD_CACHE") ?? "";
+            _host = Environment.GetEnvironmentVariable(EnvVarHost) ?? "localhost";
+            _port = Environment.GetEnvironmentVariable(EnvVarPort) ?? "8013";
+            _useTLS = bool.Parse(Environment.GetEnvironmentVariable(EnvVarTLS) ?? "false");
+            _socketPath = Environment.GetEnvironmentVariable(EnvVarSocketPath) ?? "";
+            var cacheStr = Environment.GetEnvironmentVariable(EnvVarCache) ?? "";
 
             if (cacheStr.ToUpper().Equals("LRU"))
             {
                 _cache = true;
-                _maxCacheSize = int.Parse(Environment.GetEnvironmentVariable("FLAGD_MAX_CACHE_SIZE") ?? $"{CacheSizeDefault}");
-                _maxEventStreamRetries = int.Parse(Environment.GetEnvironmentVariable("FLAGD_MAX_EVENT_STREAM_RETRIES") ?? "3");
+                _maxCacheSize = int.Parse(Environment.GetEnvironmentVariable(EnvVarMaxCacheSize) ?? $"{CacheSizeDefault}");
+                _maxEventStreamRetries = int.Parse(Environment.GetEnvironmentVariable(EnvVarMaxEventStreamRetries) ?? "3");
             }
         }
 

--- a/src/OpenFeature.Contrib.Providers.Flagd/FlagdConfig.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/FlagdConfig.cs
@@ -21,6 +21,11 @@ namespace OpenFeature.Contrib.Providers.Flagd
             get { return _maxCacheSize; }
         }
 
+        internal int MaxEventStreamRetries
+        {
+            get { return _maxEventStreamRetries; }
+        }
+
         private readonly string _host;
         private readonly string _port;
         private readonly bool _useTLS;

--- a/src/OpenFeature.Contrib.Providers.Flagd/FlagdProvider.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/FlagdProvider.cs
@@ -145,7 +145,7 @@ namespace OpenFeature.Contrib.Providers.Flagd
                 value: (bool)val.Value.AsBoolean,
                 reason: val.Reason,
                 variant: val.Variant
-            ); 
+            );
 
         }
 
@@ -179,7 +179,7 @@ namespace OpenFeature.Contrib.Providers.Flagd
                 value: val.Value.AsString,
                 reason: val.Reason,
                 variant: val.Variant
-            ); 
+            );
         }
 
         /// <summary>
@@ -333,11 +333,10 @@ namespace OpenFeature.Contrib.Providers.Flagd
                     while (await call.ResponseStream.MoveNext())
                     {
                         var response = call.ResponseStream.Current;
-                        Console.WriteLine($"Received message from server: {response.Type}");
 
                         switch (response.Type.ToLower())
                         {
-                            case "configuration_change": 
+                            case "configuration_change":
                                 HandleConfigurationChangeEvent(response.Data);
                                 break;
                             case "provider_ready":
@@ -351,7 +350,6 @@ namespace OpenFeature.Contrib.Providers.Flagd
                 catch (RpcException ex) when (ex.StatusCode == StatusCode.Unavailable)
                 {
                     // Handle the dropped connection by reconnecting and retrying the stream
-                    Console.WriteLine($"Connection to server lost: {ex}");
                     await HandleErrorEvent();
                 }
             }
@@ -375,7 +373,6 @@ namespace OpenFeature.Contrib.Providers.Flagd
                         while (changedFlags.MoveNext())
                         {
                             var flag = changedFlags.Current;
-                            Console.WriteLine($"removing changed flag {flag.Key}: {flag.Value.ToString()}");
                             _cache.Delete(flag.Key);
                         }
                     }
@@ -387,7 +384,7 @@ namespace OpenFeature.Contrib.Providers.Flagd
                 // purge the cache if we could not handle the configuration change event
                 _cache.Purge();
             }
-            
+
         }
 
         private void HandleProviderReadyEvent()

--- a/src/OpenFeature.Contrib.Providers.Flagd/FlagdProvider.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/FlagdProvider.cs
@@ -14,6 +14,7 @@ using Value = OpenFeature.Model.Value;
 using ProtoValue = Google.Protobuf.WellKnownTypes.Value;
 using System.Net.Sockets;
 using System.Net.Http;
+using System.Collections.Generic;
 
 namespace OpenFeature.Contrib.Providers.Flagd
 {
@@ -340,12 +341,9 @@ namespace OpenFeature.Contrib.Providers.Flagd
                 {
                     if (val.KindCase == ProtoValue.KindOneofCase.StructValue)
                     {
-                        var changedFlags = val.StructValue.Fields.AsEnumerable().GetEnumerator();
-                        while (changedFlags.MoveNext())
-                        {
-                            var flag = changedFlags.Current;
+                        val.StructValue.Fields.ToList().ForEach(flag => {
                             _cache.Delete(flag.Key);
-                        }
+                        });
                     }
                     var structVal = val.StructValue;
                 }

--- a/src/OpenFeature.Contrib.Providers.Flagd/FlagdProvider.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/FlagdProvider.cs
@@ -30,7 +30,6 @@ namespace OpenFeature.Contrib.Providers.Flagd
         private readonly ICache<string, ResolutionDetails<Value>> _cache;
         private int _eventStreamRetries;
         private int _eventStreamRetryBackoff = EventStreamRetryBaseBackoff;
-        private bool _providerReady;
 
         private System.Threading.Mutex _mtx;
 
@@ -392,7 +391,6 @@ namespace OpenFeature.Contrib.Providers.Flagd
             _mtx.WaitOne();
             _eventStreamRetries = 0;
             _eventStreamRetryBackoff = EventStreamRetryBaseBackoff;
-            _providerReady = true;
             _mtx.ReleaseMutex();
             _cache.Purge();
         }

--- a/src/OpenFeature.Contrib.Providers.Flagd/FlagdProvider.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/FlagdProvider.cs
@@ -341,7 +341,8 @@ namespace OpenFeature.Contrib.Providers.Flagd
                 {
                     if (val.KindCase == ProtoValue.KindOneofCase.StructValue)
                     {
-                        val.StructValue.Fields.ToList().ForEach(flag => {
+                        val.StructValue.Fields.ToList().ForEach(flag =>
+                        {
                             _cache.Delete(flag.Key);
                         });
                     }

--- a/src/OpenFeature.Contrib.Providers.Flagd/README.md
+++ b/src/OpenFeature.Contrib.Providers.Flagd/README.md
@@ -76,12 +76,15 @@ namespace OpenFeatureTestApp
 
 The URI of the flagd server to which the `flagd Provider` connects to can either be passed directly to the constructor, or be configured using the following environment variables:
 
-| Option name      | Environment variable name      | Type    | Default   | Values        |
-|------------------|--------------------------------|---------|-----------| ------------- |
-| host             | FLAGD_HOST                     | string  | localhost |               |
-| port             | FLAGD_PORT                     | number  | 8013      |               |
-| tls              | FLAGD_TLS                      | boolean | false     |               |
-| unix socket path | FLAGD_SOCKET_PATH              | string  |           |               |
+| Option name                  | Environment variable name      | Type    | Default   | Values        |
+|------------------------------|--------------------------------|---------|-----------| ------------- |
+| host                         | FLAGD_HOST                     | string  | localhost |               |
+| port                         | FLAGD_PORT                     | number  | 8013      |               |
+| tls                          | FLAGD_TLS                      | boolean | false     |               |
+| unix socket path             | FLAGD_SOCKET_PATH              | string  |           |               |
+| Caching                      | FLAGD_CACHE                    | string  |           |     LRU       |
+| Maximum cache size           | FLAGD_MAX_CACHE_SIZE           | number  | 10        |               |
+| Maximum event stream retries | FLAGD_MAX_EVENT_STREAM_RETRIES | number  | 3         |               |
 
 Note that if `FLAGD_SOCKET_PATH` is set, this value takes precedence, and the other variables (`FLAGD_HOST`, `FLAGD_PORT`, `FLAGD_TLS`) are disregarded.
 

--- a/test/OpenFeature.Contrib.Providers.Flagd.Test/CacheTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagd.Test/CacheTest.cs
@@ -65,7 +65,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             var counter = 0;
             for (int i = 0; i < capacity; i++)
             {
-                tasks.Add(System.Threading.Tasks.Task.Run(() => 
+                tasks.Add(System.Threading.Tasks.Task.Run(() =>
                 {
                     var id = System.Threading.Interlocked.Increment(ref counter);
                     cache.Add($"key-{id}", $"value-{id}");

--- a/test/OpenFeature.Contrib.Providers.Flagd.Test/CacheTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagd.Test/CacheTest.cs
@@ -1,0 +1,99 @@
+using Xunit;
+
+namespace OpenFeature.Contrib.Providers.Flagd.Test
+{
+    public class UnitTestLRUCache
+    {
+        [Fact]
+        public void TestCacheCapacity()
+        {
+            int capacity = 5;
+            var cache = new LRUCache<string, string>(capacity);
+
+            for (int i = 0; i < capacity; i++)
+            {
+                cache.Add($"key-{i}", $"value-{i}");
+            }
+
+            string value;
+            // verify that we can retrieve all items
+            for (int i = 0; i < capacity; i++)
+            {
+                value = cache.TryGet($"key-{i}");
+
+                Assert.Equal($"value-{i}", value);
+            }
+
+            // add another item - now the least recently used item ("key-0") should be replaced
+            cache.Add("new-item", "new-value");
+
+            value = cache.TryGet("key-0");
+            Assert.Null(value);
+
+            value = cache.TryGet("new-item");
+            Assert.Equal("new-value", value);
+        }
+
+        [Fact]
+        public void TestCacheDeleteOnlyItem()
+        {
+            int capacity = 5;
+            var cache = new LRUCache<string, string>(capacity);
+
+            var key = "my-key";
+            var expectedValue = "my-value";
+
+            cache.Add(key, expectedValue);
+
+            string value;
+
+            value = cache.TryGet(key);
+            Assert.Equal(expectedValue, value);
+
+            cache.Delete(key);
+            
+            value = cache.TryGet(key);
+            Assert.Null(value);
+
+            // check that we can add something again after deleting the last item
+            cache.Add(key, expectedValue);
+            Assert.Equal(expectedValue, cache.TryGet(key));
+        }
+
+        [Fact]
+        public void TestCacheDeleteHead()
+        {
+            int capacity = 5;
+            var cache = new LRUCache<string, string>(capacity);
+
+
+            cache.Add("tail", "tail");
+            cache.Add("middle", "middle");
+            cache.Add("head", "head");
+
+            cache.Delete("head");
+            
+            Assert.Null(cache.TryGet("head"));
+            Assert.Equal("middle", cache.TryGet("middle"));
+            Assert.Equal("tail", cache.TryGet("tail"));
+        }
+
+        [Fact]
+        public void TestCacheDeleteMiddle()
+        {
+            int capacity = 5;
+            var cache = new LRUCache<string, string>(capacity);
+
+
+            cache.Add("tail", "tail");
+            cache.Add("middle", "middle");
+            cache.Add("head", "head");
+
+            cache.Delete("middle");
+            
+            Assert.Null(cache.TryGet("middle"));
+            Assert.Equal("head", cache.TryGet("head"));
+            Assert.Equal("tail", cache.TryGet("tail"));
+        }
+    }
+}

--- a/test/OpenFeature.Contrib.Providers.Flagd.Test/CacheTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagd.Test/CacheTest.cs
@@ -51,7 +51,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             Assert.Equal(expectedValue, value);
 
             cache.Delete(key);
-            
+
             value = cache.TryGet(key);
             Assert.Null(value);
 
@@ -72,7 +72,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             cache.Add("head", "head");
 
             cache.Delete("head");
-            
+
             Assert.Null(cache.TryGet("head"));
             Assert.Equal("middle", cache.TryGet("middle"));
             Assert.Equal("tail", cache.TryGet("tail"));
@@ -90,7 +90,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             cache.Add("head", "head");
 
             cache.Delete("middle");
-            
+
             Assert.Null(cache.TryGet("middle"));
             Assert.Equal("head", cache.TryGet("head"));
             Assert.Equal("tail", cache.TryGet("tail"));
@@ -108,7 +108,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             cache.Add("head", "head");
 
             cache.Purge();
-            
+
             Assert.Null(cache.TryGet("head"));
             Assert.Null(cache.TryGet("middle"));
             Assert.Null(cache.TryGet("tail"));

--- a/test/OpenFeature.Contrib.Providers.Flagd.Test/CacheTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagd.Test/CacheTest.cs
@@ -95,5 +95,23 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             Assert.Equal("head", cache.TryGet("head"));
             Assert.Equal("tail", cache.TryGet("tail"));
         }
+
+        [Fact]
+        public void TestPurge()
+        {
+            int capacity = 5;
+            var cache = new LRUCache<string, string>(capacity);
+
+
+            cache.Add("tail", "tail");
+            cache.Add("middle", "middle");
+            cache.Add("head", "head");
+
+            cache.Purge();
+            
+            Assert.Null(cache.TryGet("head"));
+            Assert.Null(cache.TryGet("middle"));
+            Assert.Null(cache.TryGet("tail"));
+        }
     }
 }

--- a/test/OpenFeature.Contrib.Providers.Flagd.Test/FlagdConfigTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagd.Test/FlagdConfigTest.cs
@@ -1,0 +1,72 @@
+using Xunit;
+
+namespace OpenFeature.Contrib.Providers.Flagd.Test
+{
+    public class UnitTestFlagdConfig
+    {
+        [Fact]
+        public void TestFlagdConfigDefault()
+        {
+            CleanEnvVars();
+            var config = new FlagdConfig();
+
+            Assert.False(config.CacheEnabled);
+            Assert.Equal(new System.Uri("http://localhost:8013"), config.GetUri());
+        }
+
+        [Fact]
+        public void TestFlagdConfigUseTLS()
+        {
+            CleanEnvVars();
+            System.Environment.SetEnvironmentVariable("FLAGD_TLS", "true");
+
+            var config = new FlagdConfig();
+
+            Assert.Equal(new System.Uri("https://localhost:8013"), config.GetUri());
+        }
+
+        [Fact]
+        public void TestFlagdConfigUnixSocket()
+        {
+            CleanEnvVars();
+            System.Environment.SetEnvironmentVariable("FLAGD_SOCKET_PATH", "tmp.sock");
+
+            var config = new FlagdConfig();
+
+            Assert.Equal(new System.Uri("unix://tmp.sock/"), config.GetUri());
+        }
+
+        [Fact]
+        public void TestFlagdConfigEnabledCacheDefaultCacheSize()
+        {
+            CleanEnvVars();
+            System.Environment.SetEnvironmentVariable("FLAGD_CACHE", "LRU");
+
+            var config = new FlagdConfig();
+
+            Assert.True(config.CacheEnabled);
+            Assert.Equal(FlagdConfig.CacheSizeDefault, config.MaxCacheSize);
+        }
+
+        [Fact]
+        public void TestFlagdConfigEnabledCacheApplyCacheSize()
+        {
+            CleanEnvVars();
+            System.Environment.SetEnvironmentVariable("FLAGD_CACHE", "LRU");
+            System.Environment.SetEnvironmentVariable("FLAGD_MAX_CACHE_SIZE", "20");
+
+            var config = new FlagdConfig();
+
+            Assert.True(config.CacheEnabled);
+            Assert.Equal(20, config.MaxCacheSize);
+        }
+
+        private void CleanEnvVars()
+        {
+            System.Environment.SetEnvironmentVariable("FLAGD_TLS", "");
+            System.Environment.SetEnvironmentVariable("FLAGD_SOCKET_PATH", "");
+            System.Environment.SetEnvironmentVariable("FLAGD_CACHE", "");
+            System.Environment.SetEnvironmentVariable("FLAGD_MAX_CACHE_SIZE", "");
+        }
+    }
+}

--- a/test/OpenFeature.Contrib.Providers.Flagd.Test/FlagdConfigTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagd.Test/FlagdConfigTest.cs
@@ -18,7 +18,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
         public void TestFlagdConfigUseTLS()
         {
             CleanEnvVars();
-            System.Environment.SetEnvironmentVariable("FLAGD_TLS", "true");
+            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarTLS, "true");
 
             var config = new FlagdConfig();
 
@@ -29,7 +29,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
         public void TestFlagdConfigUnixSocket()
         {
             CleanEnvVars();
-            System.Environment.SetEnvironmentVariable("FLAGD_SOCKET_PATH", "tmp.sock");
+            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarSocketPath, "tmp.sock");
 
             var config = new FlagdConfig();
 
@@ -40,7 +40,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
         public void TestFlagdConfigEnabledCacheDefaultCacheSize()
         {
             CleanEnvVars();
-            System.Environment.SetEnvironmentVariable("FLAGD_CACHE", "LRU");
+            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarCache, "LRU");
 
             var config = new FlagdConfig();
 
@@ -52,8 +52,8 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
         public void TestFlagdConfigEnabledCacheApplyCacheSize()
         {
             CleanEnvVars();
-            System.Environment.SetEnvironmentVariable("FLAGD_CACHE", "LRU");
-            System.Environment.SetEnvironmentVariable("FLAGD_MAX_CACHE_SIZE", "20");
+            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarCache, "LRU");
+            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarMaxCacheSize, "20");
 
             var config = new FlagdConfig();
 
@@ -63,10 +63,10 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
 
         private void CleanEnvVars()
         {
-            System.Environment.SetEnvironmentVariable("FLAGD_TLS", "");
-            System.Environment.SetEnvironmentVariable("FLAGD_SOCKET_PATH", "");
-            System.Environment.SetEnvironmentVariable("FLAGD_CACHE", "");
-            System.Environment.SetEnvironmentVariable("FLAGD_MAX_CACHE_SIZE", "");
+            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarTLS, "");
+            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarSocketPath, "");
+            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarCache, "");
+            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarMaxCacheSize, "");
         }
     }
 }

--- a/test/OpenFeature.Contrib.Providers.Flagd.Test/FlagdProviderTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagd.Test/FlagdProviderTest.cs
@@ -366,9 +366,9 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
                     It.IsAny<Empty>(), null, null, System.Threading.CancellationToken.None))
                 .Returns(grpcEventStreamResp);
 
-            var mockCache = new Mock<ICache<string, ResolutionDetails<Model.Value>>>();
+            var mockCache = new Mock<ICache<string, object>>();
             mockCache.Setup(c => c.TryGet(It.Is<string>(s => s == "my-key"))).Returns(() => null);
-            mockCache.Setup(c => c.Add(It.Is<string>(s => s == "my-key"), It.IsAny<ResolutionDetails<Model.Value>>()));
+            mockCache.Setup(c => c.Add(It.Is<string>(s => s == "my-key"), It.IsAny<object>()));
 
 
             var config = new FlagdConfig();
@@ -380,7 +380,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             var val = flagdProvider.ResolveBooleanValue("my-key", false, null);
             Assert.True(val.Result.Value);
 
-            Assert.True(_autoResetEvent.WaitOne());
+            Assert.True(_autoResetEvent.WaitOne(10000));
             mockCache.VerifyAll();
             mockGrpcClient.VerifyAll();
         }
@@ -427,9 +427,9 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
                     It.IsAny<Empty>(), null, null, System.Threading.CancellationToken.None))
                 .Returns(grpcEventStreamResp);
 
-            var mockCache = new Mock<ICache<string, ResolutionDetails<Model.Value>>>();
+            var mockCache = new Mock<ICache<string, object>>();
             mockCache.Setup(c => c.TryGet(It.Is<string>(s => s == "my-key"))).Returns(
-                () => new ResolutionDetails<Model.Value>("my-key", new Model.Value(true))
+                () => new ResolutionDetails<bool>("my-key", true)
             );
 
             var config = new FlagdConfig();
@@ -442,7 +442,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             Assert.True(val.Result.Value);
 
             // wait for the autoReset event to be fired before verifying the invocation of the mocked functions
-            Assert.True(_autoResetEvent.WaitOne());
+            Assert.True(_autoResetEvent.WaitOne(10000));
             mockCache.VerifyAll();
             mockGrpcClient.VerifyAll();
         }
@@ -520,9 +520,9 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
                     return grpcEventStreamResp;
                 });
 
-            var mockCache = new Mock<ICache<string, ResolutionDetails<Model.Value>>>();
+            var mockCache = new Mock<ICache<string, object>>();
             mockCache.Setup(c => c.TryGet(It.Is<string>(s => s == "my-key"))).Returns(() => null);
-            mockCache.Setup(c => c.Add(It.Is<string>(s => s == "my-key"), It.IsAny<ResolutionDetails<Model.Value>>()));
+            mockCache.Setup(c => c.Add(It.Is<string>(s => s == "my-key"), It.IsAny<object>()));
             mockCache.Setup(c => c.Delete(It.Is<string>(s => s == "my-key"))).Callback(() =>
             {
                 // set the autoResetEvent since this path should be the last one that's reached in the background task
@@ -545,7 +545,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             val = flagdProvider.ResolveBooleanValue("my-key", false, null);
             Assert.True(val.Result.Value);
 
-            Assert.True(_autoResetEvent.WaitOne());
+            Assert.True(_autoResetEvent.WaitOne(10000));
 
             mockCache.VerifyAll();
             mockGrpcClient.VerifyAll();

--- a/test/OpenFeature.Contrib.Providers.Flagd.Test/FlagdProviderTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagd.Test/FlagdProviderTest.cs
@@ -345,7 +345,8 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             var _autoResetEvent = new AutoResetEvent(false);
 
             asyncStreamReader.Setup(a => a.MoveNext(It.IsAny<System.Threading.CancellationToken>())).ReturnsAsync(() => enumerator.MoveNext());
-            asyncStreamReader.Setup(a => a.Current).Returns(() => {
+            asyncStreamReader.Setup(a => a.Current).Returns(() =>
+            {
                 // set the autoResetEvent since this path should be the last one that's reached in the background task
                 _autoResetEvent.Set();
                 return enumerator.Current;
@@ -405,7 +406,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             AutoResetEvent _autoResetEvent = new AutoResetEvent(false);
 
             asyncStreamReader.Setup(a => a.MoveNext(It.IsAny<System.Threading.CancellationToken>())).ReturnsAsync(() => enumerator.MoveNext());
-            asyncStreamReader.Setup(a => a.Current).Returns(() => 
+            asyncStreamReader.Setup(a => a.Current).Returns(() =>
             {
                 // set the autoResetEvent since this path should be the last one that's reached in the background task
                 _autoResetEvent.Set();
@@ -483,9 +484,10 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
 
             // create an autoResetEvent which we will wait for in our test verification
             AutoResetEvent _autoResetEvent = new AutoResetEvent(false);
-            
+
             asyncStreamReader.Setup(a => a.Current).Returns(
-                () => {
+                () =>
+                {
                     if (firstCall)
                     {
                         return new EventStreamResponse
@@ -493,8 +495,6 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
                             Type = "provider_ready"
                         };
                     }
-                    // set the autoResetEvent since this path should be the last one that's reached in the background task
-                    _autoResetEvent.Set();
                     return new EventStreamResponse
                     {
                         Type = "configuration_change",
@@ -515,7 +515,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             mockGrpcClient
                 .Setup(m => m.EventStream(
                     It.IsAny<Empty>(), null, null, System.Threading.CancellationToken.None))
-                .Returns(() => 
+                .Returns(() =>
                 {
                     return grpcEventStreamResp;
                 });
@@ -523,7 +523,11 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             var mockCache = new Mock<ICache<string, ResolutionDetails<Model.Value>>>();
             mockCache.Setup(c => c.TryGet(It.Is<string>(s => s == "my-key"))).Returns(() => null);
             mockCache.Setup(c => c.Add(It.Is<string>(s => s == "my-key"), It.IsAny<ResolutionDetails<Model.Value>>()));
-            mockCache.Setup(c => c.Delete(It.Is<string>(s => s == "my-key")));
+            mockCache.Setup(c => c.Delete(It.Is<string>(s => s == "my-key"))).Callback(() =>
+            {
+                // set the autoResetEvent since this path should be the last one that's reached in the background task
+                _autoResetEvent.Set();
+            });
 
 
             var config = new FlagdConfig();


### PR DESCRIPTION
Closes #37 

This PR implements standard caching functionality for the flagd provider. The configuration is done via the following env vars:

```
| Caching                      | FLAGD_CACHE                    | string  |           |     LRU       |
| Maximum cache size           | FLAGD_MAX_CACHE_SIZE           | number  | 10        |               |
| Maximum event stream retries | FLAGD_MAX_EVENT_STREAM_RETRIES | number  | 3         |               |
```

When caching is enabled, the flagd provider will establish an `EventStream` with the flagd server via grpc, and listen for `configuration_change` events. When such an event is received for a flag that has already been cached previously, that flag will be removed from the cache. When retrieving the value of a feature flag, the value will be cached if the `Reason` of the resolution is set to `STATIC`.

*Note:* The imported version of the OF dotnet-sdk is set to `0.5` - Since this version does not yet include the `configuration_change` event type, or the `STATIC` reason type for the resolutionDetails, it might be worth to consider bumping the version of the imported dotnet-sdk as a follow up task.

*Note:* Since the Event Stream is opened in a background task, I was not quite sure how to best verify in the Unit tests that things like the removal of a cached item were properly called by the provider. Coming from Golang, I was missing something like `require.Eventually(t, len(mockCache.DeleteCalls) == 1)`.  I tried to resemble that behaviour by creating an `AutoResetEvent` that gets set in the mock implementation of the method I would like to ensure it was called. Then, using `Assert.True(_autoResetEvent.WaitOne())` I waited for the event to be triggered. This solution does seem to work, but if there is a better approach to this in C# I appreciate every input from the reviewers of this PR 