### PR TITLE
feat: Support apiKey for GO Feature Flag relay proxy v1.7.0

### DIFF
--- a/src/OpenFeature.Contrib.Providers.GOFeatureFlag/GoFeatureFlagProvider.cs
+++ b/src/OpenFeature.Contrib.Providers.GOFeatureFlag/GoFeatureFlagProvider.cs
@@ -264,7 +264,7 @@ namespace OpenFeature.Contrib.Providers.GOFeatureFlag
                 throw new FlagNotFoundError($"flag {flagKey} was not found in your configuration");
 
             if (response.StatusCode == HttpStatusCode.Unauthorized)
-                throw new UnauthorizedError("invalid api key, impossible to authenticate the provider");
+                throw new UnauthorizedError("invalid token used to contact GO Feature Flag relay proxy instance");
 
             if (response.StatusCode >= HttpStatusCode.BadRequest)
                 throw new GeneralError("impossible to contact GO Feature Flag relay proxy instance");

--- a/src/OpenFeature.Contrib.Providers.GOFeatureFlag/GoFeatureFlagProvider.cs
+++ b/src/OpenFeature.Contrib.Providers.GOFeatureFlag/GoFeatureFlagProvider.cs
@@ -62,6 +62,11 @@ namespace OpenFeature.Contrib.Providers.GOFeatureFlag
             _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(ApplicationJson));
             _httpClient.BaseAddress = new Uri(options.Endpoint);
             _serializerOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+            if (options.ApiKey != null)
+            {
+                _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", options.ApiKey);
+            }
         }
 
         /// <summary>
@@ -257,6 +262,9 @@ namespace OpenFeature.Contrib.Providers.GOFeatureFlag
             if (response.StatusCode == HttpStatusCode.NotFound)
                 throw new FlagNotFoundError($"flag {flagKey} was not found in your configuration");
 
+            if (response.StatusCode == HttpStatusCode.Unauthorized)
+                throw new UnauthorizedError("invalid api key, impossible to authenticate the provider");
+            
             if (response.StatusCode >= HttpStatusCode.BadRequest)
                 throw new GeneralError("impossible to contact GO Feature Flag relay proxy instance");
 

--- a/src/OpenFeature.Contrib.Providers.GOFeatureFlag/GoFeatureFlagProvider.cs
+++ b/src/OpenFeature.Contrib.Providers.GOFeatureFlag/GoFeatureFlagProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -64,9 +65,8 @@ namespace OpenFeature.Contrib.Providers.GOFeatureFlag
             _serializerOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 
             if (options.ApiKey != null)
-            {
-                _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", options.ApiKey);
-            }
+                _httpClient.DefaultRequestHeaders.Authorization =
+                    new AuthenticationHeaderValue("Bearer", options.ApiKey);
         }
 
         /// <summary>
@@ -186,7 +186,8 @@ namespace OpenFeature.Contrib.Providers.GOFeatureFlag
             try
             {
                 var resp = await CallApi(flagKey, defaultValue, context);
-                return new ResolutionDetails<double>(flagKey, double.Parse(resp.value.ToString(), System.Globalization.CultureInfo.InvariantCulture), ErrorType.None,
+                return new ResolutionDetails<double>(flagKey,
+                    double.Parse(resp.value.ToString(), CultureInfo.InvariantCulture), ErrorType.None,
                     resp.reason, resp.variationType);
             }
             catch (FormatException e)
@@ -264,7 +265,7 @@ namespace OpenFeature.Contrib.Providers.GOFeatureFlag
 
             if (response.StatusCode == HttpStatusCode.Unauthorized)
                 throw new UnauthorizedError("invalid api key, impossible to authenticate the provider");
-            
+
             if (response.StatusCode >= HttpStatusCode.BadRequest)
                 throw new GeneralError("impossible to contact GO Feature Flag relay proxy instance");
 

--- a/src/OpenFeature.Contrib.Providers.GOFeatureFlag/GoFeatureFlagProviderOptions.cs
+++ b/src/OpenFeature.Contrib.Providers.GOFeatureFlag/GoFeatureFlagProviderOptions.cs
@@ -25,16 +25,14 @@ namespace OpenFeature.Contrib.Providers.GOFeatureFlag
         ///     Default: null
         /// </Summary>
         public HttpMessageHandler HttpMessageHandler { get; set; }
-        
+
         /// <Summary>
         ///     (optional) If the relay proxy is configured to authenticate the request, you should provide
-        ///         an API Key to the provider.
-        ///         Please ask the administrator of the relay proxy to provide an API Key.
-        ///         (This feature is available only if you are using GO Feature Flag relay proxy v1.7.0 or above)
+        ///     an API Key to the provider.
+        ///     Please ask the administrator of the relay proxy to provide an API Key.
+        ///     (This feature is available only if you are using GO Feature Flag relay proxy v1.7.0 or above)
         ///     Default: null
         /// </Summary>
         public string ApiKey { get; set; }
-
-
     }
 }

--- a/src/OpenFeature.Contrib.Providers.GOFeatureFlag/GoFeatureFlagProviderOptions.cs
+++ b/src/OpenFeature.Contrib.Providers.GOFeatureFlag/GoFeatureFlagProviderOptions.cs
@@ -25,5 +25,16 @@ namespace OpenFeature.Contrib.Providers.GOFeatureFlag
         ///     Default: null
         /// </Summary>
         public HttpMessageHandler HttpMessageHandler { get; set; }
+        
+        /// <Summary>
+        ///     (optional) If the relay proxy is configured to authenticate the request, you should provide
+        ///         an API Key to the provider.
+        ///         Please ask the administrator of the relay proxy to provide an API Key.
+        ///         (This feature is available only if you are using GO Feature Flag relay proxy v1.7.0 or above)
+        ///     Default: null
+        /// </Summary>
+        public string ApiKey { get; set; }
+
+
     }
 }

--- a/src/OpenFeature.Contrib.Providers.GOFeatureFlag/GoFeatureFlagUser.cs
+++ b/src/OpenFeature.Contrib.Providers.GOFeatureFlag/GoFeatureFlagUser.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-
 using OpenFeature.Contrib.Providers.GOFeatureFlag.exception;
 using OpenFeature.Model;
 
@@ -15,17 +14,17 @@ namespace OpenFeature.Contrib.Providers.GOFeatureFlag
         private const string KeyField = "targetingKey";
 
         /// <summary>
-        ///   The targeting key for the user.
+        ///     The targeting key for the user.
         /// </summary>
         public string Key { get; private set; }
 
         /// <summary>
-        ///   Is the user Anonymous.
+        ///     Is the user Anonymous.
         /// </summary>
         public bool Anonymous { get; private set; }
 
         /// <summary>
-        ///   Additional Custom Data to pass to GO Feature Flag.
+        ///     Additional Custom Data to pass to GO Feature Flag.
         /// </summary>
         public Dictionary<string, object> Custom { get; private set; }
 

--- a/src/OpenFeature.Contrib.Providers.GOFeatureFlag/exception/UnauthorizedError.cs
+++ b/src/OpenFeature.Contrib.Providers.GOFeatureFlag/exception/UnauthorizedError.cs
@@ -1,0 +1,22 @@
+using System;
+using OpenFeature.Constant;
+using OpenFeature.Error;
+
+namespace OpenFeature.Contrib.Providers.GOFeatureFlag.exception
+{
+    /// <summary>
+    ///     Exception throw when we don't have a specific case.
+    /// </summary>
+    public class UnauthorizedError : FeatureProviderException
+    {
+        /// <summary>
+        ///     Constructor of the exception
+        /// </summary>
+        /// <param name="message">Message to display</param>
+        /// <param name="innerException">Original exception</param>
+        public UnauthorizedError(string message, Exception innerException = null) : base(ErrorType.General, message,
+            innerException)
+        {
+        }
+    }
+}

--- a/src/OpenFeature.Contrib.Providers.GOFeatureFlag/exception/UnauthorizedError.cs
+++ b/src/OpenFeature.Contrib.Providers.GOFeatureFlag/exception/UnauthorizedError.cs
@@ -5,7 +5,7 @@ using OpenFeature.Error;
 namespace OpenFeature.Contrib.Providers.GOFeatureFlag.exception
 {
     /// <summary>
-    ///     Exception throw when we don't have a specific case.
+    ///     Exception throw when we are not authorized to call the API in the relay proxy.
     /// </summary>
     public class UnauthorizedError : FeatureProviderException
     {

--- a/test/OpenFeature.Contrib.Providers.GOFeatureFlag.Test/GoFeatureFlagProviderTest.cs
+++ b/test/OpenFeature.Contrib.Providers.GOFeatureFlag.Test/GoFeatureFlagProviderTest.cs
@@ -150,7 +150,7 @@ public class GoFeatureFlagProviderTest
         Assert.Equal(ErrorType.General, res.Result.ErrorType);
         Assert.Equal(Reason.Error, res.Result.Reason);
     }
-    
+
     [Fact]
     private void should_have_bad_request_if_no_token()
     {
@@ -168,7 +168,7 @@ public class GoFeatureFlagProviderTest
         Assert.Equal(Reason.Error, res.Result.Reason);
         Assert.Equal(ErrorType.General, res.Result.ErrorType);
     }
-    
+
     [Fact]
     private void should_have_unauthorized_if_invalid_token()
     {
@@ -177,7 +177,7 @@ public class GoFeatureFlagProviderTest
             Endpoint = baseUrl,
             HttpMessageHandler = _mockHttp,
             Timeout = new TimeSpan(1000 * TimeSpan.TicksPerMillisecond),
-            ApiKey  = "ff877c7a-4594-43b5-89a8-df44c9984bd8"
+            ApiKey = "ff877c7a-4594-43b5-89a8-df44c9984bd8"
         });
         Api.Instance.SetProvider(g);
         var client = Api.Instance.GetClient("test-client");

--- a/test/OpenFeature.Contrib.Providers.GOFeatureFlag.Test/GoFeatureFlagUserTest.cs
+++ b/test/OpenFeature.Contrib.Providers.GOFeatureFlag.Test/GoFeatureFlagUserTest.cs
@@ -1,7 +1,5 @@
 using System.Text.Json;
-
 using OpenFeature.Model;
-
 using Xunit;
 
 namespace OpenFeature.Contrib.Providers.GOFeatureFlag.Test;
@@ -22,8 +20,10 @@ public class GoFeatureFlagUserTest
 
         GoFeatureFlagUser user = userContext;
 
-        var userAsString = JsonSerializer.Serialize(user, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        var userAsString = JsonSerializer.Serialize(user,
+            new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
 
-        Assert.Contains("{\"key\":\"1d1b9238-2591-4a47-94cf-d2bc080892f1\",\"anonymous\":false,\"custom\":{", userAsString);
+        Assert.Contains("{\"key\":\"1d1b9238-2591-4a47-94cf-d2bc080892f1\",\"anonymous\":false,\"custom\":{",
+            userAsString);
     }
 }


### PR DESCRIPTION
## This PR
Since version `v1.7.0` GO Feature Flag relay proxy support an authorization key.
This PR make it possible to send this API Key to the proxy.


### Related Issues
Fixes https://github.com/thomaspoignant/go-feature-flag/issues/666
