### PR TITLE
fix: NET462 requires TLS for GRPC to work

### DIFF
--- a/src/OpenFeature.Contrib.Providers.Flagd/FlagdProvider.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/FlagdProvider.cs
@@ -559,7 +559,7 @@ namespace OpenFeature.Contrib.Providers.Flagd
                         };
 #elif NET462_OR_GREATER
                         handler.ServerCertificateValidationCallback = (message, cert, chain, errors) => {
-                            if ((errors & SslPolicyErrors.None) > 0) { return true; }
+                            if (errors == SslPolicyErrors.None) { return true; }
 
                             chain.ChainPolicy.VerificationFlags = X509VerificationFlags.AllowUnknownCertificateAuthority;
 

--- a/src/OpenFeature.Contrib.Providers.Flagd/FlagdProvider.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/FlagdProvider.cs
@@ -333,7 +333,7 @@ namespace OpenFeature.Contrib.Providers.Flagd
         {
             while (_eventStreamRetries < _config.MaxEventStreamRetries)
             {
-                var call = _client.EventStream(new EventStreamRequest());
+                var call = _client.EventStream(new Empty());
                 try
                 {
                     // Read the response stream asynchronously
@@ -533,8 +533,6 @@ namespace OpenFeature.Contrib.Providers.Flagd
                     return new Value();
             }
         }
-
-        
 
         private Service.ServiceClient BuildClientForPlatform(Uri url)
         {

--- a/src/OpenFeature.Contrib.Providers.Flagd/README.md
+++ b/src/OpenFeature.Contrib.Providers.Flagd/README.md
@@ -89,6 +89,7 @@ The URI of the flagd server to which the `flagd Provider` connects to can either
 
 Note that if `FLAGD_SOCKET_PATH` is set, this value takes precedence, and the other variables (`FLAGD_HOST`, `FLAGD_PORT`, `FLAGD_TLS`, `FLAGD_SERVER_CERT_PATH`) are disregarded.
 
+Note that if you are on `NET462` through `NET48` as the target framework for your project, you are required to enable TLS and supply a certificate path as part of your configuration.  This is a limitation Microsoft has [documented](https://learn.microsoft.com/en-us/aspnet/core/grpc/netstandard?view=aspnetcore-7.0#net-framework).
 
 If you rely on the environment variables listed above, you can use the empty constructor which then configures the provider accordingly:
 


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
Currently, this provider is listed on NuGet.org as being compatible with .Net Framework 4.6.2+.  While this does compile and link properly, it does not function at all with that.  .Net Framework 4.6.2+ requires TLS to be used with GRPC or else GRPC flat out doesn't work, specified here in their [documentation](https://learn.microsoft.com/en-us/aspnet/core/grpc/netstandard?view=aspnetcore-7.0#net-framework).

The code here verifies that the cert provided matches the server cert and ignores self signed errors for .Net Framework 4.6.2 through .Net Framework 4.8.1.

### Related Issues
#73 

### Notes
I also ran into a compiler error on line 336 with `new Empty()` not being the right type and fixed it.  My limited testing shows it had no adverse effects.

### How to test
<!-- if applicable, add testing instructions under this section -->
Create a self signed server certificate and launch the Flagd docker image with it as well as some of the sample flag data.  Then launch a dummy client that uses the provider and is also using the server certificate and TLS env vars setup, then just evaluate one of the flags.

