### PR TITLE
fix: Setup config correct when passing a Uri (fixes #71)

### DIFF
--- a/src/OpenFeature.Contrib.Providers.Flagd/FlagdConfig.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/FlagdConfig.cs
@@ -75,6 +75,23 @@ namespace OpenFeature.Contrib.Providers.Flagd
                 _maxEventStreamRetries = int.Parse(Environment.GetEnvironmentVariable(EnvVarMaxEventStreamRetries) ?? "3");
             }
         }
+        
+        internal FlagdConfig(Uri url)
+        {
+            _host = url.Host;
+            _port = url.Port.ToString();
+            _useTLS = url.Scheme.ToLower().Equals("https");
+            _cert = Environment.GetEnvironmentVariable(EnvCertPart) ?? "";
+            _socketPath = url.Scheme.ToLower().Equals("unix") ? url.GetComponents(UriComponents.AbsoluteUri &~ UriComponents.Scheme, UriFormat.UriEscaped) : "";
+            var cacheStr = Environment.GetEnvironmentVariable(EnvVarCache) ?? "";
+
+            if (cacheStr.ToUpper().Equals("LRU"))
+            {
+                _cache = true;
+                _maxCacheSize = int.Parse(Environment.GetEnvironmentVariable(EnvVarMaxCacheSize) ?? $"{CacheSizeDefault}");
+                _maxEventStreamRetries = int.Parse(Environment.GetEnvironmentVariable(EnvVarMaxEventStreamRetries) ?? "3");
+            }
+        }
 
         internal Uri GetUri()
         {

--- a/src/OpenFeature.Contrib.Providers.Flagd/FlagdConfig.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/FlagdConfig.cs
@@ -78,6 +78,11 @@ namespace OpenFeature.Contrib.Providers.Flagd
         
         internal FlagdConfig(Uri url)
         {
+            if (url == null)
+            {
+                throw new ArgumentNullException(nameof(url));
+            }
+            
             _host = url.Host;
             _port = url.Port.ToString();
             _useTLS = url.Scheme.ToLower().Equals("https");

--- a/src/OpenFeature.Contrib.Providers.Flagd/FlagdConfig.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/FlagdConfig.cs
@@ -75,19 +75,19 @@ namespace OpenFeature.Contrib.Providers.Flagd
                 _maxEventStreamRetries = int.Parse(Environment.GetEnvironmentVariable(EnvVarMaxEventStreamRetries) ?? "3");
             }
         }
-        
+
         internal FlagdConfig(Uri url)
         {
             if (url == null)
             {
                 throw new ArgumentNullException(nameof(url));
             }
-            
+
             _host = url.Host;
             _port = url.Port.ToString();
             _useTLS = url.Scheme.ToLower().Equals("https");
             _cert = Environment.GetEnvironmentVariable(EnvCertPart) ?? "";
-            _socketPath = url.Scheme.ToLower().Equals("unix") ? url.GetComponents(UriComponents.AbsoluteUri &~ UriComponents.Scheme, UriFormat.UriEscaped) : "";
+            _socketPath = url.Scheme.ToLower().Equals("unix") ? url.GetComponents(UriComponents.AbsoluteUri & ~UriComponents.Scheme, UriFormat.UriEscaped) : "";
             var cacheStr = Environment.GetEnvironmentVariable(EnvVarCache) ?? "";
 
             if (cacheStr.ToUpper().Equals("LRU"))

--- a/src/OpenFeature.Contrib.Providers.Flagd/FlagdProvider.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/FlagdProvider.cs
@@ -50,22 +50,8 @@ namespace OpenFeature.Contrib.Providers.Flagd
         ///     FLAGD_MAX_CACHE_SIZE           - The maximum size of the cache (default="10")
         ///     FLAGD_MAX_EVENT_STREAM_RETRIES - The maximum amount of retries for establishing the EventStream
         /// </summary>
-        public FlagdProvider()
+        public FlagdProvider() : this(new FlagdConfig())
         {
-            _config = new FlagdConfig();
-
-            _client = BuildClientForPlatform(_config.GetUri());
-
-            _mtx = new System.Threading.Mutex();
-
-            if (_config.CacheEnabled)
-            {
-                _cache = new LRUCache<string, object>(_config.MaxCacheSize);
-                Task.Run(async () =>
-                {
-                    await HandleEvents();
-                });
-            }
         }
 
         /// <summary>
@@ -78,27 +64,8 @@ namespace OpenFeature.Contrib.Providers.Flagd
         ///     <param name="url">The URL of the flagD server</param>
         ///     <exception cref="ArgumentNullException">if no url is provided.</exception>
         /// </summary>
-        public FlagdProvider(Uri url)
+        public FlagdProvider(Uri url) : this(new FlagdConfig(url))
         {
-            if (url == null)
-            {
-                throw new ArgumentNullException(nameof(url));
-            }
-            
-            _config = new FlagdConfig(url);
-
-            _mtx = new System.Threading.Mutex();
-
-            _client = BuildClientForPlatform(url);
-            
-            if (_config.CacheEnabled)
-            {
-                _cache = new LRUCache<string, object>(_config.MaxCacheSize);
-                Task.Run(async () =>
-                {
-                    await HandleEvents();
-                });
-            }
         }
 
         /// <summary>

--- a/test/OpenFeature.Contrib.Providers.Flagd.Test/FlagdConfigTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagd.Test/FlagdConfigTest.cs
@@ -90,7 +90,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             Assert.False(config.CacheEnabled);
             Assert.Equal(new System.Uri("http://domain:8123"), config.GetUri());
         }
-        
+
         [Fact]
         public void TestFlagdConfigFromUriHttps()
         {
@@ -100,7 +100,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             Assert.False(config.CacheEnabled);
             Assert.Equal(new System.Uri("https://domain:8123"), config.GetUri());
         }
-        
+
         [Fact]
         public void TestFlagdConfigFromUriUnix()
         {
@@ -110,7 +110,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             Assert.False(config.CacheEnabled);
             Assert.Equal(new System.Uri("unix:///var/run/tmp.sock/"), config.GetUri());
         }
-        
+
         [Fact]
         public void TestFlagdConfigFromUriSetCertificatePath()
         {
@@ -129,7 +129,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             Assert.Equal("", config.CertificatePath);
             Assert.False(config.UseCertificate);
         }
-        
+
         [Fact]
         public void TestFlagdConfigFromUriEnabledCacheDefaultCacheSize()
         {
@@ -141,7 +141,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             Assert.True(config.CacheEnabled);
             Assert.Equal(FlagdConfig.CacheSizeDefault, config.MaxCacheSize);
         }
-        
+
         [Fact]
         public void TestFlagdConfigFromUriEnabledCacheApplyCacheSize()
         {

--- a/test/OpenFeature.Contrib.Providers.Flagd.Test/FlagdConfigTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagd.Test/FlagdConfigTest.cs
@@ -1,3 +1,4 @@
+using System;
 using Xunit;
 
 namespace OpenFeature.Contrib.Providers.Flagd.Test
@@ -78,6 +79,80 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
 
             Assert.Equal("", config.CertificatePath);
             Assert.False(config.UseCertificate);
+        }
+
+        [Fact]
+        public void TestFlagdConfigFromUriHttp()
+        {
+            CleanEnvVars();
+            var config = new FlagdConfig(new Uri("http://domain:8123"));
+
+            Assert.False(config.CacheEnabled);
+            Assert.Equal(new System.Uri("http://domain:8123"), config.GetUri());
+        }
+        
+        [Fact]
+        public void TestFlagdConfigFromUriHttps()
+        {
+            CleanEnvVars();
+            var config = new FlagdConfig(new Uri("https://domain:8123"));
+
+            Assert.False(config.CacheEnabled);
+            Assert.Equal(new System.Uri("https://domain:8123"), config.GetUri());
+        }
+        
+        [Fact]
+        public void TestFlagdConfigFromUriUnix()
+        {
+            CleanEnvVars();
+            var config = new FlagdConfig(new Uri("unix:///var/run/tmp.sock/"));
+
+            Assert.False(config.CacheEnabled);
+            Assert.Equal(new System.Uri("unix:///var/run/tmp.sock/"), config.GetUri());
+        }
+        
+        [Fact]
+        public void TestFlagdConfigFromUriSetCertificatePath()
+        {
+            CleanEnvVars();
+            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvCertPart, "/cert/path");
+
+            var config = new FlagdConfig(new Uri("http://localhost:8013"));
+
+            Assert.Equal("/cert/path", config.CertificatePath);
+            Assert.True(config.UseCertificate);
+
+            CleanEnvVars();
+
+            config = new FlagdConfig(new Uri("http://localhost:8013"));
+
+            Assert.Equal("", config.CertificatePath);
+            Assert.False(config.UseCertificate);
+        }
+        
+        [Fact]
+        public void TestFlagdConfigFromUriEnabledCacheDefaultCacheSize()
+        {
+            CleanEnvVars();
+            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarCache, "LRU");
+
+            var config = new FlagdConfig(new Uri("http://localhost:8013"));
+
+            Assert.True(config.CacheEnabled);
+            Assert.Equal(FlagdConfig.CacheSizeDefault, config.MaxCacheSize);
+        }
+        
+        [Fact]
+        public void TestFlagdConfigFromUriEnabledCacheApplyCacheSize()
+        {
+            CleanEnvVars();
+            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarCache, "LRU");
+            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarMaxCacheSize, "20");
+
+            var config = new FlagdConfig(new Uri("http://localhost:8013"));
+
+            Assert.True(config.CacheEnabled);
+            Assert.Equal(20, config.MaxCacheSize);
         }
 
         private void CleanEnvVars()

--- a/test/OpenFeature.Contrib.Providers.Flagd.Test/FlagdConfigTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagd.Test/FlagdConfigTest.cs
@@ -12,36 +12,36 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             var config = new FlagdConfig();
 
             Assert.False(config.CacheEnabled);
-            Assert.Equal(new System.Uri("http://localhost:8013"), config.GetUri());
+            Assert.Equal(new Uri("http://localhost:8013"), config.GetUri());
         }
 
         [Fact]
         public void TestFlagdConfigUseTLS()
         {
             CleanEnvVars();
-            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarTLS, "true");
+            Environment.SetEnvironmentVariable(FlagdConfig.EnvVarTLS, "true");
 
             var config = new FlagdConfig();
 
-            Assert.Equal(new System.Uri("https://localhost:8013"), config.GetUri());
+            Assert.Equal(new Uri("https://localhost:8013"), config.GetUri());
         }
 
         [Fact]
         public void TestFlagdConfigUnixSocket()
         {
             CleanEnvVars();
-            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarSocketPath, "tmp.sock");
+            Environment.SetEnvironmentVariable(FlagdConfig.EnvVarSocketPath, "tmp.sock");
 
             var config = new FlagdConfig();
 
-            Assert.Equal(new System.Uri("unix://tmp.sock/"), config.GetUri());
+            Assert.Equal(new Uri("unix://tmp.sock/"), config.GetUri());
         }
 
         [Fact]
         public void TestFlagdConfigEnabledCacheDefaultCacheSize()
         {
             CleanEnvVars();
-            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarCache, "LRU");
+            Environment.SetEnvironmentVariable(FlagdConfig.EnvVarCache, "LRU");
 
             var config = new FlagdConfig();
 
@@ -53,8 +53,8 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
         public void TestFlagdConfigEnabledCacheApplyCacheSize()
         {
             CleanEnvVars();
-            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarCache, "LRU");
-            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarMaxCacheSize, "20");
+            Environment.SetEnvironmentVariable(FlagdConfig.EnvVarCache, "LRU");
+            Environment.SetEnvironmentVariable(FlagdConfig.EnvVarMaxCacheSize, "20");
 
             var config = new FlagdConfig();
 
@@ -66,7 +66,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
         public void TestFlagdConfigSetCertificatePath()
         {
             CleanEnvVars();
-            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvCertPart, "/cert/path");
+            Environment.SetEnvironmentVariable(FlagdConfig.EnvCertPart, "/cert/path");
 
             var config = new FlagdConfig();
 
@@ -88,7 +88,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             var config = new FlagdConfig(new Uri("http://domain:8123"));
 
             Assert.False(config.CacheEnabled);
-            Assert.Equal(new System.Uri("http://domain:8123"), config.GetUri());
+            Assert.Equal(new Uri("http://domain:8123"), config.GetUri());
         }
 
         [Fact]
@@ -98,24 +98,24 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             var config = new FlagdConfig(new Uri("https://domain:8123"));
 
             Assert.False(config.CacheEnabled);
-            Assert.Equal(new System.Uri("https://domain:8123"), config.GetUri());
+            Assert.Equal(new Uri("https://domain:8123"), config.GetUri());
         }
 
         [Fact]
         public void TestFlagdConfigFromUriUnix()
         {
             CleanEnvVars();
-            var config = new FlagdConfig(new Uri("unix:///var/run/tmp.sock/"));
+            var config = new FlagdConfig(new Uri("unix:///var/run/tmp.sock"));
 
             Assert.False(config.CacheEnabled);
-            Assert.Equal(new System.Uri("unix:///var/run/tmp.sock/"), config.GetUri());
+            Assert.Equal(new Uri("unix:///var/run/tmp.sock"), config.GetUri());
         }
 
         [Fact]
         public void TestFlagdConfigFromUriSetCertificatePath()
         {
             CleanEnvVars();
-            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvCertPart, "/cert/path");
+            Environment.SetEnvironmentVariable(FlagdConfig.EnvCertPart, "/cert/path");
 
             var config = new FlagdConfig(new Uri("http://localhost:8013"));
 
@@ -134,7 +134,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
         public void TestFlagdConfigFromUriEnabledCacheDefaultCacheSize()
         {
             CleanEnvVars();
-            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarCache, "LRU");
+            Environment.SetEnvironmentVariable(FlagdConfig.EnvVarCache, "LRU");
 
             var config = new FlagdConfig(new Uri("http://localhost:8013"));
 
@@ -146,8 +146,8 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
         public void TestFlagdConfigFromUriEnabledCacheApplyCacheSize()
         {
             CleanEnvVars();
-            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarCache, "LRU");
-            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarMaxCacheSize, "20");
+            Environment.SetEnvironmentVariable(FlagdConfig.EnvVarCache, "LRU");
+            Environment.SetEnvironmentVariable(FlagdConfig.EnvVarMaxCacheSize, "20");
 
             var config = new FlagdConfig(new Uri("http://localhost:8013"));
 
@@ -157,11 +157,11 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
 
         private void CleanEnvVars()
         {
-            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarTLS, "");
-            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarSocketPath, "");
-            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarCache, "");
-            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarMaxCacheSize, "");
-            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvCertPart, "");
+            Environment.SetEnvironmentVariable(FlagdConfig.EnvVarTLS, "");
+            Environment.SetEnvironmentVariable(FlagdConfig.EnvVarSocketPath, "");
+            Environment.SetEnvironmentVariable(FlagdConfig.EnvVarCache, "");
+            Environment.SetEnvironmentVariable(FlagdConfig.EnvVarMaxCacheSize, "");
+            Environment.SetEnvironmentVariable(FlagdConfig.EnvCertPart, "");
         }
     }
 }

--- a/test/OpenFeature.Contrib.Providers.Flagd.Test/FlagdProviderTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagd.Test/FlagdProviderTest.cs
@@ -116,6 +116,44 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarCache, "");
             System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarMaxCacheSize, "");
         }
+        
+        [Fact]
+        public void TestGetProviderWithUri()
+        {
+            // Set env variables (should be used by the constructor)
+            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvCertPart, "");
+            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarCache, "LRU");
+            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarMaxCacheSize, "20");
+            
+            // Set env variables (should be ignored by the constructor)
+            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarHost, "localhost111");
+            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarPort, "5001");
+            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarTLS, "false");
+
+            // Create provider, which ignores the env vars and uses the config
+            var flagdProvider = new FlagdProvider(new Uri("https://localhost:8013"));
+
+            // Client should no be nil
+            var client = flagdProvider.GetClient();
+            Assert.NotNull(client);
+
+            // Retrieve config for assertions
+            var config = flagdProvider.GetConfig();
+
+            // Assert
+            Assert.Equal("", config.CertificatePath);
+            Assert.Equal(new Uri("https://localhost:8013"), config.GetUri());
+            Assert.True(config.CacheEnabled);
+            Assert.Equal(20, config.MaxCacheSize);
+
+            // Cleanup
+            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvCertPart, "");
+            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarHost, "");
+            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarPort, "");
+            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarTLS, "");
+            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarCache, "");
+            System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarMaxCacheSize, "");
+        }
 
         [Fact]
         public void TestResolveBooleanValue()

--- a/test/OpenFeature.Contrib.Providers.Flagd.Test/FlagdProviderTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagd.Test/FlagdProviderTest.cs
@@ -116,7 +116,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarCache, "");
             System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarMaxCacheSize, "");
         }
-        
+
         [Fact]
         public void TestGetProviderWithUri()
         {
@@ -124,7 +124,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             System.Environment.SetEnvironmentVariable(FlagdConfig.EnvCertPart, "");
             System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarCache, "LRU");
             System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarMaxCacheSize, "20");
-            
+
             // Set env variables (should be ignored by the constructor)
             System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarHost, "localhost111");
             System.Environment.SetEnvironmentVariable(FlagdConfig.EnvVarPort, "5001");


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR

Provider can now be created with a `Uri`. Anything related to the URI is no longer read from environment variables, everything else is.

### Related Issues
Fixes #71 

### Notes
My unix socket knowledge is pretty slim, unit test in place to cover the basics and appears to do as expected.


### How to test
N/A

