### PR TITLE
fix: do not send targeting key as separate trait in flagsmith

### DIFF
--- a/src/OpenFeature.Contrib.Providers.Flagsmith/FlagsmithProvider.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagsmith/FlagsmithProvider.cs
@@ -73,7 +73,11 @@ namespace OpenFeature.Contrib.Providers.Flagsmith
 
             return string.IsNullOrEmpty(key)
                 ? _flagsmithClient.GetEnvironmentFlags()
-                : _flagsmithClient.GetIdentityFlags(key, ctx.AsDictionary().Select(x => new Trait(x.Key, x.Value.AsObject) as ITrait).ToList());
+                : _flagsmithClient.GetIdentityFlags(key, ctx
+                    .AsDictionary()
+                    .Where(x => x.Key != Configuration.TargetingKey)
+                    .Select(x => new Trait(x.Key, x.Value.AsObject) as ITrait)
+                    .ToList());
         }
 
         private async Task<ResolutionDetails<T>> ResolveValue<T>(string flagKey, T defaultValue, TryParseDelegate<T> tryParse, EvaluationContext context)

--- a/src/OpenFeature.Contrib.Providers.Flagsmith/FlagsmithProviderConfiguration.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagsmith/FlagsmithProviderConfiguration.cs
@@ -6,9 +6,14 @@
 public class FlagsmithProviderConfiguration : IFlagsmithProviderConfiguration
 {
     /// <summary>
+    /// Default value for targeting key
+    /// </summary>
+    public const string DefaultTargetingKey = "targetingKey";
+
+    /// <summary>
     /// Key that will be used as identity for Flagsmith requests. Default: "targetingKey"
     /// </summary>
-    public string TargetingKey { get; set; } = "targetingKey";
+    public string TargetingKey { get; set; } = DefaultTargetingKey;
 
     /// <inheritdoc/>
     public bool UsingBooleanConfigValue { get; set; }

--- a/test/OpenFeature.Contrib.Providers.Flagsmith.Test/FlagsmithProviderTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagsmith.Test/FlagsmithProviderTest.cs
@@ -65,7 +65,7 @@ namespace OpenFeature.Contrib.Providers.Flagsmith.Test
             var date = DateTime.Now;
             flags.GetFeatureValue("example-feature").Returns("true");
             flags.IsFeatureEnabled("example-feature").Returns(true);
-            flagsmithClient.GetIdentityFlags("233", Arg.Is<List<ITrait>>(x => x.Count == 7 && x.Any(c => c.GetTraitKey() == "key1"))).Returns(flags);
+            flagsmithClient.GetIdentityFlags("233", Arg.Is<List<ITrait>>(x => x.Count == 6 && x.Any(c => c.GetTraitKey() == "key1"))).Returns(flags);
 
             var providerConfig = GetDefaultFlagsmithProviderConfigurationConfiguration();
             var flagsmithProvider = new FlagsmithProvider(providerConfig, flagsmithClient);
@@ -77,7 +77,7 @@ namespace OpenFeature.Contrib.Providers.Flagsmith.Test
                 .Set("key4", date)
                 .Set("key5", Structure.Empty)
                 .Set("key6", 1.0)
-                .Set("targetingKey", "233");
+                .Set(FlagsmithProviderConfiguration.DefaultTargetingKey, "233");
             // Act
             var result = await flagsmithProvider.ResolveBooleanValue("example-feature", false, contextBuilder.Build());
 


### PR DESCRIPTION
## This PR
- Removes targeting key (identity) from traits list to avoid unnecessary duplication
