### PR TITLE
refactor: Reduce OTel dependencies

### DIFF
--- a/src/OpenFeature.Contrib.Hooks.Otel/OpenFeature.Contrib.Hooks.Otel.csproj
+++ b/src/OpenFeature.Contrib.Hooks.Otel/OpenFeature.Contrib.Hooks.Otel.csproj
@@ -13,8 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.4.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.4.0" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.4.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The `OpenFeature.Contrib.Hooks.Otel` project currently references (1) an exporter implementation which libraries should _not_ do under any normal circumstances, and (2) the main `OpenTelemetry` package which is excessive given all of the excellent work by the `dotnet/runtime` and `open-telemetry/opentelemetry-dotnet` teams have done over the last couple of years to ensure that the BCL types in `System.Diagnostics` conform to OTel standards.

This commit removes (1) and pares down (2) to from `OpenTelemetry` to `OpenTelemetry.Api` to shrink the dependency footprint we ship to consumers.

_At this point, I would argue that this hooks package should meet the minimal dependency requirement for upstream inclusion in the main OpenFeature package, but deferring that discussion for now._
