### PR TITLE
chore: SourceLink is built-in for .NET SDK 8.0.100+

### DIFF
--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -25,10 +25,4 @@
     <None Include="$(MSBuildThisFileDirectory)openfeature-icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 
-  <PropertyGroup Label="SourceLink">
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-  </PropertyGroup>
 </Project>

--- a/build/Common.props
+++ b/build/Common.props
@@ -23,7 +23,6 @@
       Please sort alphabetically.
       Refer to https://docs.microsoft.com/nuget/concepts/package-versioning for semver syntax.
     -->
-    <MicrosoftSourceLinkGitHubPkgVer>[1.0.0,2.0)</MicrosoftSourceLinkGitHubPkgVer>
     <!-- 0.5+ -->
     <OpenFeatureVer>[1.2,)</OpenFeatureVer>
   </PropertyGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,11 +1,4 @@
 <Project>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubPkgVer)">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
   <PropertyGroup>
     <TargetFrameworkMonikerAssemblyAttributesPath>$([System.IO.Path]::Combine('$(IntermediateOutputPath)','$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)'))</TargetFrameworkMonikerAssemblyAttributesPath>
   </PropertyGroup>


### PR DESCRIPTION
- https://learn.microsoft.com/dotnet/core/compatibility/sdk/8.0/source-link

> ## [Using Source Link in .NET projects](https://github.com/dotnet/sourcelink?tab=readme-ov-file#using-source-link-in-net-projects)
> 
> Starting with .NET 8, Source Link for the following source control providers is included in the .NET SDK and enabled by default:
> - [GitHub](http://github.com) or [GitHub Enterprise](https://enterprise.github.com/home) 
> - [Azure Repos](https://azure.microsoft.com/en-us/services/devops/repos) git repositories (formerly known as Visual Studio Team Services)
> - [GitLab](https://gitlab.com) 12.0+ (for older versions see [GitLab settings](#gitlab))
> - [Bitbucket](https://bitbucket.org/) 4.7+ (for older versions see [Bitbucket settings](#bitbucket))
> 
> If your project uses .NET SDK 8+ and is hosted by the above providers it does not need to reference any Source Link packages or set any build properties.
> 
> **Otherwise**, you can enable Source Link experience in your project by setting a few properties and adding a PackageReference to a Source Link package specific to the provider:
> 
> ```xml
> <Project>
>  <PropertyGroup>
>     <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
>     <PublishRepositoryUrl>true</PublishRepositoryUrl>
>  
>     <!-- Optional: Embed source files that are not tracked by the source control manager in the PDB -->
>     <EmbedUntrackedSources>true</EmbedUntrackedSources>
>   </PropertyGroup>
>   <ItemGroup>
>     <!-- Add PackageReference specific for your source control provider (see below) --> 
>   </ItemGroup>
> </Project>
> ```

See: open-feature/dotnet-sdk#198