### PR TITLE
fix: Update usage of StatsigServerOptions

### DIFF
--- a/src/OpenFeature.Contrib.Providers.Statsig/EvaluationContextExtensions.cs
+++ b/src/OpenFeature.Contrib.Providers.Statsig/EvaluationContextExtensions.cs
@@ -5,7 +5,7 @@ namespace OpenFeature.Contrib.Providers.Statsig
 {
     internal static class EvaluationContextExtensions
     {
-        //These keys match the keys of the statsiguser object as descibed here
+        //These keys match the keys of the statsiguser object as described here
         //https://docs.statsig.com/client/concepts/user
         internal const string CONTEXT_APP_VERSION = "appVersion";
         internal const string CONTEXT_COUNTRY = "country";

--- a/src/OpenFeature.Contrib.Providers.Statsig/README.md
+++ b/src/OpenFeature.Contrib.Providers.Statsig/README.md
@@ -10,12 +10,12 @@ The first things we will do is install the **Open Feature SDK** and the **Statsi
 
 ### .NET Cli
 ```shell
-dotnet add package  OpenFeature.Contrib.Provider.Statsig
+dotnet add package OpenFeature.Contrib.Provider.Statsig
 ```
 ### Package Manager
 
 ```shell
-NuGet\Install-Package  OpenFeature.Contrib.Provider.Statsig
+NuGet\Install-Package OpenFeature.Contrib.Provider.Statsig
 ```
 ### Package Reference
 
@@ -25,16 +25,16 @@ NuGet\Install-Package  OpenFeature.Contrib.Provider.Statsig
 ### Packet cli
 
 ```shell
-paket add  OpenFeature.Contrib.Provider.Statsig
+paket add OpenFeature.Contrib.Provider.Statsig
 ```
 
 ### Cake
 
 ```shell
-// Install  OpenFeature.Contrib.Provider.Statsig as a Cake Addin
+// Install OpenFeature.Contrib.Provider.Statsig as a Cake Addin
 #addin nuget:?package= OpenFeature.Contrib.Provider.Statsig
 
-// Install  OpenFeature.Contrib.Provider.Statsig as a Cake Tool
+// Install OpenFeature.Contrib.Provider.Statsig as a Cake Tool
 #tool nuget:?package= OpenFeature.Contrib.Provider.Statsig
 ```
 
@@ -44,7 +44,7 @@ The following example shows how to use the Statsig provider with the OpenFeature
 
 ```csharp
 using OpenFeature;
-using  OpenFeature.Contrib.Provider.Statsig;
+using OpenFeature.Contrib.Provider.Statsig;
 using System;
 
 StatsigProvider statsigProvider = new StatsigProvider("#YOUR-SDK-KEY#");

--- a/src/OpenFeature.Contrib.Providers.Statsig/README.md
+++ b/src/OpenFeature.Contrib.Providers.Statsig/README.md
@@ -10,32 +10,32 @@ The first things we will do is install the **Open Feature SDK** and the **Statsi
 
 ### .NET Cli
 ```shell
-dotnet add package OpenFeature.Contrib.Providers.Statsig
+dotnet add package  OpenFeature.Contrib.Provider.Statsig
 ```
 ### Package Manager
 
 ```shell
-NuGet\Install-Package OpenFeature.Contrib.Providers.Statsig
+NuGet\Install-Package  OpenFeature.Contrib.Provider.Statsig
 ```
 ### Package Reference
 
 ```xml
-<PackageReference Include="OpenFeature.Contrib.Providers.Statsig" />
+<PackageReference Include=" OpenFeature.Contrib.Provider.Statsig" />
 ```
 ### Packet cli
 
 ```shell
-paket add OpenFeature.Contrib.Providers.Statsig
+paket add  OpenFeature.Contrib.Provider.Statsig
 ```
 
 ### Cake
 
 ```shell
-// Install OpenFeature.Contrib.Providers.Statsig as a Cake Addin
-#addin nuget:?package=OpenFeature.Contrib.Providers.Statsig
+// Install  OpenFeature.Contrib.Provider.Statsig as a Cake Addin
+#addin nuget:?package= OpenFeature.Contrib.Provider.Statsig
 
-// Install OpenFeature.Contrib.Providers.Statsig as a Cake Tool
-#tool nuget:?package=OpenFeature.Contrib.Providers.Statsig
+// Install  OpenFeature.Contrib.Provider.Statsig as a Cake Tool
+#tool nuget:?package= OpenFeature.Contrib.Provider.Statsig
 ```
 
 ## Using the Statsig Provider with the OpenFeature SDK
@@ -44,7 +44,7 @@ The following example shows how to use the Statsig provider with the OpenFeature
 
 ```csharp
 using OpenFeature;
-using OpenFeature.Contrib.Providers.Statsig;
+using  OpenFeature.Contrib.Provider.Statsig;
 using System;
 
 StatsigProvider statsigProvider = new StatsigProvider("#YOUR-SDK-KEY#");

--- a/src/OpenFeature.Contrib.Providers.Statsig/StatsigProvider.cs
+++ b/src/OpenFeature.Contrib.Providers.Statsig/StatsigProvider.cs
@@ -32,14 +32,12 @@ namespace OpenFeature.Contrib.Providers.Statsig
         /// </summary>
         /// <param name="sdkKey">SDK Key to access Statsig.</param>
         /// <param name="configurationAction">The action used to configure the client.</param>
-        public StatsigProvider(string sdkKey = null, Action<StatsigServerOptions> configurationAction = null)
+        public StatsigProvider(string sdkKey = null, StatsigServerOptions configurationAction = null)
         {
             if (sdkKey != null)
             {
                 _sdkKey = sdkKey;
             }
-            _options = new StatsigServerOptions();
-            configurationAction?.Invoke(_options);
             ServerDriver = new ServerDriver(_sdkKey, _options);
         }
 

--- a/src/OpenFeature.Contrib.Providers.Statsig/StatsigProvider.cs
+++ b/src/OpenFeature.Contrib.Providers.Statsig/StatsigProvider.cs
@@ -24,21 +24,20 @@ namespace OpenFeature.Contrib.Providers.Statsig
         volatile bool initialized = false;
         private readonly Metadata _providerMetadata = new Metadata("Statsig provider");
         private readonly string _sdkKey = "secret-"; //Dummy sdk key that works with local mode
-        private readonly StatsigServerOptions _options;
         internal readonly ServerDriver ServerDriver;
 
         /// <summary>
         /// Creates new instance of <see cref="StatsigProvider"/>
         /// </summary>
         /// <param name="sdkKey">SDK Key to access Statsig.</param>
-        /// <param name="configurationAction">The action used to configure the client.</param>
-        public StatsigProvider(string sdkKey = null, StatsigServerOptions configurationAction = null)
+        /// <param name="statsigServerOptions">The StatsigServerOptions to configure the provider.</param>
+        public StatsigProvider(string sdkKey = null, StatsigServerOptions statsigServerOptions = null)
         {
             if (sdkKey != null)
             {
                 _sdkKey = sdkKey;
             }
-            ServerDriver = new ServerDriver(_sdkKey, _options);
+            ServerDriver = new ServerDriver(_sdkKey, statsigServerOptions);
         }
 
         /// <inheritdoc/>

--- a/test/OpenFeature.Contrib.Providers.Statsig.Test/StatsigProviderTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Statsig.Test/StatsigProviderTest.cs
@@ -4,6 +4,7 @@ using OpenFeature.Error;
 using OpenFeature.Model;
 using System.Threading.Tasks;
 using Xunit;
+using Statsig;
 namespace OpenFeature.Contrib.Providers.Statsig.Test;
 
 public class StatsigProviderTest
@@ -12,7 +13,7 @@ public class StatsigProviderTest
 
     public StatsigProviderTest()
     {
-        statsigProvider = new StatsigProvider("secret-", x => x.LocalMode = true);
+        statsigProvider = new StatsigProvider("secret-", new StatsigServerOptions() { LocalMode = true });
     }
 
     [Fact]


### PR DESCRIPTION
## This PR updates the way `StatsigServerOptions `are passed to the `StatsigProvider`
The previous api took an `Action<StatsigServerOptions>`. While this was a nicer api, it did unfortunately not work as most of the fields on `StatsigServerOptions` can only be set in the constructor.

### Notes
A few typos are also fixed

### Follow-up Tasks
The updates in the README uncovers an example of the inconsistency mentioned [here](https://github.com/open-feature/dotnet-sdk-contrib/issues/154). I'm considering whether to rename the NuGet package (OpenFeature.Contrib.Provider**s**.Statsig) to match the Project name (OpenFeature.Contrib.Providers.Statsig) 
