### PR TITLE
fix: Install latest .net 8 sdk during build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
         dotnet-version: |
           6.0.x
           7.0.x
+          8.0.x
         source-url: https://nuget.pkg.github.com/open-feature/index.json
 
     - name: Restore
@@ -72,6 +73,7 @@ jobs:
         dotnet-version: |
           6.0.x
           7.0.x
+          8.0.x
         source-url: https://nuget.pkg.github.com/open-feature/index.json
 
     - name: Copy Gherkin
@@ -106,6 +108,7 @@ jobs:
         dotnet-version: |
           6.0.x
           7.0.x
+          8.0.x
         source-url: https://nuget.pkg.github.com/open-feature/index.json
 
     - name: Restore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
           dotnet-version: |
             6.0.x
             7.0.x
+            8.0.x
           source-url: https://nuget.pkg.github.com/open-feature/index.json
 
       - name: Install dependencies


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
- installs the latest .net 8 sdk during build
https://github.com/open-feature/dotnet-sdk-contrib/pull/141 updates dotnet sdk to `8.0.203`. This is however not installed on github runners by default.

### Related Issues
Fixes the error blocking https://github.com/open-feature/dotnet-sdk-contrib/pull/141
Similar issue [here](https://github.com/open-feature/dotnet-sdk/pull/218)

### How to test
After merging this to the renovate branch, the actions on https://github.com/open-feature/dotnet-sdk-contrib/pull/141 should succeed.
