### PR TITLE
fix: Use new Statsig Api to return default value when flag is not defined

### DIFF
--- a/src/OpenFeature.Contrib.Providers.Statsig/README.md
+++ b/src/OpenFeature.Contrib.Providers.Statsig/README.md
@@ -94,6 +94,3 @@ The following parameters are mapped to the corresponding Statsig pre-defined par
 
 ## Known issues and limitations
 - Only `ResolveBooleanValue` implemented for now
-
-- Gate BooleanEvaluation with default value true cannot fallback to true.
-  https://github.com/statsig-io/dotnet-sdk/issues/33


### PR DESCRIPTION
## This PR
- updates the Statsig provider so it now returns the default value when a flag is not defined

### Notes
Fix was made possible after the Statsig added the new `GetFeatureGate` API [here](https://github.com/statsig-io/dotnet-sdk/commit/f3ddca04360555fa98974c8837fed78624d557f1)