### PR TITLE
fix(flagsmith/tests): don't use empty string in default configuration

### DIFF
--- a/test/OpenFeature.Contrib.Providers.Flagsmith.Test/FlagsmithProviderTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagsmith.Test/FlagsmithProviderTest.cs
@@ -17,7 +17,7 @@ namespace OpenFeature.Contrib.Providers.Flagsmith.Test
         private static FlagsmithConfiguration GetDefaultFlagsmithConfiguration() => new()
         {
             ApiUrl = "https://edge.api.flagsmith.com/api/v1/",
-            EnvironmentKey = string.Empty,
+            EnvironmentKey = "some-key",
             EnableClientSideEvaluation = false,
             EnvironmentRefreshIntervalSeconds = 60,
             EnableAnalytics = false,


### PR DESCRIPTION
## This PR

Fixes the unit tests against the Flagsmith provider which set up the client with an empty environment key. This feels like a breaking change, however, the client would not work with an empty environment key so shouldn't cause any harm. 

Happy to discuss further if needed. 

### Related Issues

https://github.com/open-feature/dotnet-sdk-contrib/pull/184

### How to test

```
dotnet test
```

