### PR TITLE
refactor: Use the newly introduced ConfigCat error codes to determine error type

### DIFF
--- a/src/OpenFeature.Contrib.Providers.ConfigCat/OpenFeature.Contrib.Providers.ConfigCat.csproj
+++ b/src/OpenFeature.Contrib.Providers.ConfigCat/OpenFeature.Contrib.Providers.ConfigCat.csproj
@@ -16,6 +16,6 @@
     </AssemblyAttribute>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ConfigCat.Client" Version="[9,)"/>
+    <PackageReference Include="ConfigCat.Client" Version="9.2.0"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## This PR

ConfigCat .NET SDK has recently [introduced error codes](https://github.com/configcat/.net-sdk/releases/tag/v9.2.0) to allow consumers to detect the reason for errors that occur during evaluation in a more reliable way than guessing it by matching error message strings.

This PR upgrades the OpenFeature provider for ConfigCat to the new SDK version and adjusts the provider implementation to leverage this new feature.