### PR TITLE
fix!: in-process var name/value (FLAGD_RESOLVER="in-process")

### DIFF
--- a/src/OpenFeature.Contrib.Providers.Flagd/FlagdConfig.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/FlagdConfig.cs
@@ -36,9 +36,11 @@ namespace OpenFeature.Contrib.Providers.Flagd
         internal const string EnvVarCache = "FLAGD_CACHE";
         internal const string EnvVarMaxCacheSize = "FLAGD_MAX_CACHE_SIZE";
         internal const string EnvVarMaxEventStreamRetries = "FLAGD_MAX_EVENT_STREAM_RETRIES";
-        internal const string EnvVarResolverType = "FLAGD_RESOLVER_TYPE";
+        internal const string EnvVarResolverType = "FLAGD_RESOLVER";
         internal const string EnvVarSourceSelector = "FLAGD_SOURCE_SELECTOR";
         internal static int CacheSizeDefault = 10;
+        internal static string InProcessResolverValue = "in-process";
+        internal static string LruCacheValue = "lru";
 
         /// <summary>
         /// Get a FlagdConfigBuilder instance.
@@ -170,7 +172,7 @@ namespace OpenFeature.Contrib.Providers.Flagd
             _sourceSelector = Environment.GetEnvironmentVariable(EnvVarSourceSelector) ?? "";
             var cacheStr = Environment.GetEnvironmentVariable(EnvVarCache) ?? "";
 
-            if (string.Equals(cacheStr, "LRU", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(cacheStr, LruCacheValue, StringComparison.OrdinalIgnoreCase))
             {
                 _cache = true;
                 _maxCacheSize = int.Parse(Environment.GetEnvironmentVariable(EnvVarMaxCacheSize) ?? $"{CacheSizeDefault}");
@@ -178,7 +180,7 @@ namespace OpenFeature.Contrib.Providers.Flagd
             }
 
             var resolverTypeStr = Environment.GetEnvironmentVariable(EnvVarResolverType) ?? "RPC";
-            _resolverType = resolverTypeStr.ToUpper().Equals("IN_PROCESS") ? ResolverType.IN_PROCESS : ResolverType.RPC;
+            _resolverType = string.Equals(resolverTypeStr, InProcessResolverValue, StringComparison.OrdinalIgnoreCase) ? ResolverType.IN_PROCESS : ResolverType.RPC;
         }
 
         internal FlagdConfig(Uri url)
@@ -197,7 +199,7 @@ namespace OpenFeature.Contrib.Providers.Flagd
 
             var cacheStr = Environment.GetEnvironmentVariable(EnvVarCache) ?? "";
 
-            if (string.Equals(cacheStr, "LRU", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(cacheStr, LruCacheValue, StringComparison.OrdinalIgnoreCase))
             {
                 _cache = true;
                 _maxCacheSize = int.Parse(Environment.GetEnvironmentVariable(EnvVarMaxCacheSize) ?? $"{CacheSizeDefault}");
@@ -205,7 +207,7 @@ namespace OpenFeature.Contrib.Providers.Flagd
             }
 
             var resolverTypeStr = Environment.GetEnvironmentVariable(EnvVarResolverType) ?? "RPC";
-            _resolverType = resolverTypeStr.ToUpper().Equals("IN_PROCESS") ? ResolverType.IN_PROCESS : ResolverType.RPC;
+            _resolverType = string.Equals(resolverTypeStr, InProcessResolverValue, StringComparison.OrdinalIgnoreCase) ? ResolverType.IN_PROCESS : ResolverType.RPC;
         }
 
         internal Uri GetUri()

--- a/src/OpenFeature.Contrib.Providers.Flagd/FlagdProvider.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/FlagdProvider.cs
@@ -33,7 +33,7 @@ namespace OpenFeature.Contrib.Providers.Flagd
         ///     FLAGD_CACHE                    - Enable or disable the cache (default="false")
         ///     FLAGD_MAX_CACHE_SIZE           - The maximum size of the cache (default="10")
         ///     FLAGD_MAX_EVENT_STREAM_RETRIES - The maximum amount of retries for establishing the EventStream
-        ///     FLAGD_RESOLVER_TYPE            - The type of resolver (in-process or rpc) to be used for the provider
+        ///     FLAGD_RESOLVER                 - The type of resolver (in-process or rpc) to be used for the provider
         /// </summary>
         public FlagdProvider() : this(new FlagdConfig())
         {
@@ -46,7 +46,7 @@ namespace OpenFeature.Contrib.Providers.Flagd
         ///     FLAGD_CACHE                    - Enable or disable the cache (default="false")
         ///     FLAGD_MAX_CACHE_SIZE           - The maximum size of the cache (default="10")
         ///     FLAGD_MAX_EVENT_STREAM_RETRIES - The maximum amount of retries for establishing the EventStream
-        ///     FLAGD_RESOLVER_TYPE            - The type of resolver (in-process or rpc) to be used for the provider
+        ///     FLAGD_RESOLVER            - The type of resolver (in-process or rpc) to be used for the provider
         ///     <param name="url">The URL of the flagd server</param>
         ///     <exception cref="ArgumentNullException">if no url is provided.</exception>
         /// </summary>

--- a/src/OpenFeature.Contrib.Providers.Flagd/README.md
+++ b/src/OpenFeature.Contrib.Providers.Flagd/README.md
@@ -77,16 +77,16 @@ namespace OpenFeatureTestApp
 The URI of the flagd server to which the `flagd Provider` connects to can either be passed directly to the constructor, or be configured using the following environment variables:
 
 | Option name                  | Environment variable name      | Type    | Default   | Values          |
-|------------------------------|--------------------------------|---------|-----------| --------------- |
+| ---------------------------- | ------------------------------ | ------- | --------- | --------------- |
 | host                         | FLAGD_HOST                     | string  | localhost |                 |
 | port                         | FLAGD_PORT                     | number  | 8013      |                 |
 | tls                          | FLAGD_TLS                      | boolean | false     |                 |
 | tls certPath                 | FLAGD_SERVER_CERT_PATH         | string  |           |                 |
 | unix socket path             | FLAGD_SOCKET_PATH              | string  |           |                 |
-| Caching                      | FLAGD_CACHE                    | string  |           |     LRU         |
+| Caching                      | FLAGD_CACHE                    | string  |           | lru             |
 | Maximum cache size           | FLAGD_MAX_CACHE_SIZE           | number  | 10        |                 |
 | Maximum event stream retries | FLAGD_MAX_EVENT_STREAM_RETRIES | number  | 3         |                 |
-| Resolver type                | FLAGD_RESOLVER_TYPE            | string  | RPC       | RPC, IN_PROCESS |
+| Resolver type                | FLAGD_RESOLVER                 | string  | rpc       | rpc, in-process |
 | Source selector              | FLAGD_SOURCE_SELECTOR          | string  |           |                 |
 
 Note that if `FLAGD_SOCKET_PATH` is set, this value takes precedence, and the other variables (`FLAGD_HOST`, `FLAGD_PORT`, `FLAGD_TLS`, `FLAGD_SERVER_CERT_PATH`) are disregarded.
@@ -112,7 +112,7 @@ var unixFlagdProvider = new FlagdProvider(new Uri("unix://socket.tmp"));
 ## In-process resolver type
 
 The flagd provider also supports the [in-process provider mode](https://flagd.dev/reference/specifications/in-process-providers/),
-which is activated by setting the `FLAGD_RESOLVER_TYPE` env var to `IN_PROCESS`.
+which is activated by setting the `FLAGD_RESOLVER` env var to `IN_PROCESS`.
 In this mode, the provider will connect to a service implementing the [flagd.sync.v1 interface](https://github.com/open-feature/flagd-schemas/blob/main/protobuf/flagd/sync/v1/sync.proto)
 and subscribe to a feature flag configuration determined by the `FLAGD_SOURCE_SELECTOR`.
 After an initial retrieval of the desired flag configuration, the in-process provider will keep the latest known state in memory,

--- a/test/OpenFeature.Contrib.Providers.Flagd.Test/FlagdConfigTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagd.Test/FlagdConfigTest.cs
@@ -41,7 +41,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
         public void TestFlagdConfigEnabledCacheDefaultCacheSize()
         {
             Utils.CleanEnvVars();
-            Environment.SetEnvironmentVariable(FlagdConfig.EnvVarCache, "LRU");
+            Environment.SetEnvironmentVariable(FlagdConfig.EnvVarCache, "lru");
 
             var config = new FlagdConfig();
 
@@ -159,7 +159,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
         public void TestFlagdConfigResolverType()
         {
             Utils.CleanEnvVars();
-            Environment.SetEnvironmentVariable(FlagdConfig.EnvVarResolverType, "IN_PROCESS");
+            Environment.SetEnvironmentVariable(FlagdConfig.EnvVarResolverType, "in-process");
             Environment.SetEnvironmentVariable(FlagdConfig.EnvVarSourceSelector, "source-selector");
 
             var config = new FlagdConfig(new Uri("http://localhost:8013"));


### PR DESCRIPTION
Corrects the name/value of the in-process mode env var as per https://flagd.dev/providers/nodejs/?h=flagd_resolver#available-configuration-options