### PR TITLE
feat: relative weights in fractional, fix injected props

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,12 +50,12 @@ jobs:
     services:
       # flagd-testbed for flagd RPC provider e2e tests
       flagd:
-        image: ghcr.io/open-feature/flagd-testbed:v0.5.4
+        image: ghcr.io/open-feature/flagd-testbed:v0.5.6
         ports:
           - 8013:8013
       # sync-testbed for flagd in-process provider e2e tests
       sync:
-        image: ghcr.io/open-feature/sync-testbed:v0.5.4
+        image: ghcr.io/open-feature/sync-testbed:v0.5.6
         ports:
           - 9090:9090
     steps:

--- a/src/OpenFeature.Contrib.Providers.Flagd/Resolver/InProcess/CustomEvaluators/FlagdProperties.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/Resolver/InProcess/CustomEvaluators/FlagdProperties.cs
@@ -17,7 +17,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Resolver.InProcess.CustomEvaluator
         internal FlagdProperties(object from)
         {
             //object value;
-            if (from is Dictionary<string, object> dict)
+            if (from is IDictionary<string, object> dict)
             {
                 if (dict.TryGetValue(TargetingKeyKey, out object targetingKeyValue)
                     && targetingKeyValue is string targetingKeyString)
@@ -25,7 +25,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Resolver.InProcess.CustomEvaluator
                     TargetingKey = targetingKeyString;
                 }
                 if (dict.TryGetValue(FlagdPropertiesKey, out object flagdPropertiesObj)
-                    && flagdPropertiesObj is Dictionary<string, object> flagdProperties)
+                    && flagdPropertiesObj is IDictionary<string, object> flagdProperties)
                 {
                     if (flagdProperties.TryGetValue(FlagKeyKey, out object flagKeyObj)
                         && flagKeyObj is string flagKey)

--- a/src/OpenFeature.Contrib.Providers.Flagd/Resolver/InProcess/CustomEvaluators/FractionalEvaluator.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/Resolver/InProcess/CustomEvaluators/FractionalEvaluator.cs
@@ -49,16 +49,19 @@ namespace OpenFeature.Contrib.Providers.Flagd.Resolver.InProcess.CustomEvaluator
 
             var flagdProperties = new FlagdProperties(data);
 
-            // check if the first argument is a string (i.e. the property to base the distribution on
-            var propertyValue = flagdProperties.TargetingKey;
             var bucketStartIndex = 0;
 
             var arg0 = p.Apply(args[0], data);
 
+            string propertyValue;
             if (arg0 is string stringValue)
             {
                 propertyValue = stringValue;
                 bucketStartIndex = 1;
+            }
+            else
+            {
+                propertyValue = flagdProperties.FlagKey + flagdProperties.TargetingKey;
             }
 
             var distributions = new List<FractionalEvaluationDistribution>();
@@ -96,7 +99,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Resolver.InProcess.CustomEvaluator
                 distributionSum += weight;
             }
 
-            var valueToDistribute = flagdProperties.FlagKey + propertyValue;
+            var valueToDistribute = propertyValue;
             var murmur32 = MurmurHash.Create32();
             var bytes = Encoding.ASCII.GetBytes(valueToDistribute);
             var hashBytes = murmur32.ComputeHash(bytes);

--- a/src/OpenFeature.Contrib.Providers.Flagd/docker-compose.yaml
+++ b/src/OpenFeature.Contrib.Providers.Flagd/docker-compose.yaml
@@ -1,25 +1,17 @@
 services:
   flagd:
-    build:
-      context: flagd-testbed
-      dockerfile: flagd/Dockerfile
+    image: ghcr.io/open-feature/flagd-testbed:v0.5.6
     ports:
       - 8013:8013
   flagd-unstable:
-    build:
-      context: flagd-testbed
-      dockerfile: flagd/Dockerfile.unstable
+    image: ghcr.io/open-feature/flagd-testbed-unstable:v0.5.6
     ports:
       - 8014:8013
   flagd-sync:
-    build:
-      context: flagd-testbed
-      dockerfile: sync/Dockerfile
+    image: ghcr.io/open-feature/sync-testbed:v0.5.6
     ports:
       - 9090:9090
   flagd-sync-unstable:
-    build:
-      context: flagd-testbed
-      dockerfile: sync/Dockerfile.unstable
+    image: ghcr.io/open-feature/sync-testbed-unstable:v0.5.6
     ports:
       - 9091:9090

--- a/test/OpenFeature.Contrib.Providers.Flagd.E2e.Test/Steps/EvaluationStepDefinitionBase.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagd.E2e.Test/Steps/EvaluationStepDefinitionBase.cs
@@ -1,8 +1,7 @@
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.ComponentModel.DataAnnotations;
-using System.Text.RegularExpressions;
+using System.ComponentModel;
+using System.Reflection;
 using System.Threading.Tasks;
 using OpenFeature.Constant;
 using OpenFeature.Model;
@@ -245,7 +244,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.E2e.Test
         public void Giventhereasonshouldindicateanerrorandtheerrorcodeshouldindicateamissingflagwith(string errorCode)
         {
             Assert.Equal(Reason.Error.ToString(), notFoundDetails.Reason);
-            Assert.Contains(errorCode, notFoundDetails.ErrorMessage);
+            Assert.Contains(errorCode, GetErrorTypeDescription(notFoundDetails.ErrorType));
         }
 
         [When(@"a string flag with key ""(.*)"" is evaluated as an integer, with details and a default value (.*)")]
@@ -266,7 +265,15 @@ namespace OpenFeature.Contrib.Providers.Flagd.E2e.Test
         public void Giventhereasonshouldindicateanerrorandtheerrorcodeshouldindicateatypemismatchwith(string errorCode)
         {
             Assert.Equal(Reason.Error.ToString(), typeErrorDetails.Reason);
-            Assert.Contains(errorCode, this.typeErrorDetails.ErrorMessage);
+            Assert.Contains(errorCode, GetErrorTypeDescription(typeErrorDetails.ErrorType));
+        }
+
+        // convenience method to get the enum description.
+        private string GetErrorTypeDescription(Enum value)
+        {
+            FieldInfo info = value.GetType().GetField(value.ToString());
+            DescriptionAttribute[] attributes = (DescriptionAttribute[])info.GetCustomAttributes(typeof(DescriptionAttribute));
+            return attributes[0].Description;
         }
     }
 }

--- a/test/OpenFeature.Contrib.Providers.Flagd.Test/FractionalEvaluatorTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagd.Test/FractionalEvaluatorTest.cs
@@ -61,12 +61,12 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
         [MemberData(nameof(FractionalEvaluationTestData.FractionalEvaluationContext), MemberType = typeof(FractionalEvaluationTestData))]
         public void EvaluateUsingRelativeWeights(string email, string flagKey, string expected)
         {
-                // Arrange
-                var evaluator = new JsonLogicEvaluator(EvaluateOperators.Default);
-                var fractionalEvaluator = new FractionalEvaluator();
-                EvaluateOperators.Default.AddOperator("fractional", fractionalEvaluator.Evaluate);
+            // Arrange
+            var evaluator = new JsonLogicEvaluator(EvaluateOperators.Default);
+            var fractionalEvaluator = new FractionalEvaluator();
+            EvaluateOperators.Default.AddOperator("fractional", fractionalEvaluator.Evaluate);
 
-                var targetingString = @"{""fractional"": [
+            var targetingString = @"{""fractional"": [
                     {
                         ""var"": [
                             ""email""
@@ -75,17 +75,17 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
                     [""red"", 5], [""blue"", 5], [""green"", 5], [""yellow"", 5],
                 ]}";
 
-                // Parse json into hierarchical structure
-                var rule = JObject.Parse(targetingString);
+            // Parse json into hierarchical structure
+            var rule = JObject.Parse(targetingString);
 
-                var data = new Dictionary<string, object> {
+            var data = new Dictionary<string, object> {
                 { "email", email },
                 {"$flagd", new Dictionary<string, object> { {"flagKey", flagKey } } }
                 };
 
-                // Act & Assert
-                var result = evaluator.Apply(rule, data);
-                Assert.Equal(expected, result.ToString());
+            // Act & Assert
+            var result = evaluator.Apply(rule, data);
+            Assert.Equal(expected, result.ToString());
         }
 
         [Theory]

--- a/test/OpenFeature.Contrib.Providers.Flagd.Test/FractionalEvaluatorTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagd.Test/FractionalEvaluatorTest.cs
@@ -37,8 +37,9 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
 
             var targetingString = @"{""fractional"": [
               {
-                ""var"": [
-                  ""email""
+                ""cat"": [
+                    { ""var"":""$flagd.flagKey"" },
+                    { ""var"":""email"" }
                 ]
               },
               [""red"", 25], [""blue"", 25], [""green"", 25], [""yellow"", 25], 
@@ -68,8 +69,9 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
 
             var targetingString = @"{""fractional"": [
                     {
-                        ""var"": [
-                            ""email""
+                        ""cat"": [
+                            { ""var"":""$flagd.flagKey"" },
+                            { ""var"":""email"" }
                         ]
                     },
                     [""red"", 5], [""blue"", 5], [""green"", 5], [""yellow"", 5],
@@ -99,8 +101,9 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
 
             var targetingString = @"{""fractional"": [
             {
-                ""var"": [
-                ""email""
+                ""cat"": [
+                    { ""var"":""$flagd.flagKey"" },
+                    { ""var"":""email"" }
                 ]
             },
             [""red""], [""blue""], [""green""], [""yellow""],

--- a/test/OpenFeature.Contrib.Providers.Flagd.Test/FractionalEvaluatorTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagd.Test/FractionalEvaluatorTest.cs
@@ -55,7 +55,68 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             // Act & Assert
             var result = evaluator.Apply(rule, data);
             Assert.Equal(expected, result.ToString());
+        }
 
+        [Theory]
+        [MemberData(nameof(FractionalEvaluationTestData.FractionalEvaluationContext), MemberType = typeof(FractionalEvaluationTestData))]
+        public void EvaluateUsingRelativeWeights(string email, string flagKey, string expected)
+        {
+                // Arrange
+                var evaluator = new JsonLogicEvaluator(EvaluateOperators.Default);
+                var fractionalEvaluator = new FractionalEvaluator();
+                EvaluateOperators.Default.AddOperator("fractional", fractionalEvaluator.Evaluate);
+
+                var targetingString = @"{""fractional"": [
+                    {
+                        ""var"": [
+                            ""email""
+                        ]
+                    },
+                    [""red"", 5], [""blue"", 5], [""green"", 5], [""yellow"", 5],
+                ]}";
+
+                // Parse json into hierarchical structure
+                var rule = JObject.Parse(targetingString);
+
+                var data = new Dictionary<string, object> {
+                { "email", email },
+                {"$flagd", new Dictionary<string, object> { {"flagKey", flagKey } } }
+                };
+
+                // Act & Assert
+                var result = evaluator.Apply(rule, data);
+                Assert.Equal(expected, result.ToString());
+        }
+
+        [Theory]
+        [MemberData(nameof(FractionalEvaluationTestData.FractionalEvaluationContext), MemberType = typeof(FractionalEvaluationTestData))]
+        public void EvaluateUsingDefaultWeights(string email, string flagKey, string expected)
+        {
+            // Arrange
+            var evaluator = new JsonLogicEvaluator(EvaluateOperators.Default);
+            var fractionalEvaluator = new FractionalEvaluator();
+            EvaluateOperators.Default.AddOperator("fractional", fractionalEvaluator.Evaluate);
+
+            var targetingString = @"{""fractional"": [
+            {
+                ""var"": [
+                ""email""
+                ]
+            },
+            [""red""], [""blue""], [""green""], [""yellow""],
+            ]}";
+
+            // Parse json into hierarchical structure
+            var rule = JObject.Parse(targetingString);
+
+            var data = new Dictionary<string, object> {
+            { "email", email },
+            {"$flagd", new Dictionary<string, object> { {"flagKey", flagKey } } }
+            };
+
+            // Act & Assert
+            var result = evaluator.Apply(rule, data);
+            Assert.Equal(expected, result.ToString());
         }
 
         [Theory]


### PR DESCRIPTION
This PR adds support for relative weights in the fractional evaluator. This new (non breaking) feature has been proposed in https://github.com/open-feature/flagd/issues/1282 (The related PR to implement this in flagd is this one: https://github.com/open-feature/flagd/pull/1313).
In addition to supporting relative weights instead of percentages, the weight value for a distribution item can be omitted. In this case, a default weight of `1` will be applied.

Leaving this in draft until the related PR in flagd has been merged