### PR TITLE
feat: map to Statsig CustomIDs

### DIFF
--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -20,10 +20,10 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v4
 
-    - name: Setup .NET Core 6.0
+    - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
+        global-json-file: global.json
 
     - name: Install format tool
       run: dotnet tool install -g dotnet-format

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "8.0.203"
+    "version": "8.0.301"
   }
 }

--- a/src/OpenFeature.Contrib.Providers.Statsig/EvaluationContextExtensions.cs
+++ b/src/OpenFeature.Contrib.Providers.Statsig/EvaluationContextExtensions.cs
@@ -59,10 +59,10 @@ namespace OpenFeature.Contrib.Providers.Statsig
                         if (item.Value.IsStructure)
                         {
                             var customIds = item.Value.AsStructure;
-                            foreach (var items in customIds)
+                            foreach (var customId in customIds)
                             {
-                                if (item.Value.IsString)
-                                    user.AddCustomID(items.Key, items.Value.AsString);
+                                if (customId.Value.IsString)
+                                    user.AddCustomID(customId.Key, customId.Value.AsString);
                                 else throw new FeatureProviderException(Constant.ErrorType.TypeMismatch, "Only string values are supported for CustomIDs");
                             }
                         }

--- a/src/OpenFeature.Contrib.Providers.Statsig/EvaluationContextExtensions.cs
+++ b/src/OpenFeature.Contrib.Providers.Statsig/EvaluationContextExtensions.cs
@@ -1,4 +1,5 @@
-﻿using OpenFeature.Model;
+﻿using OpenFeature.Error;
+using OpenFeature.Model;
 using Statsig;
 
 namespace OpenFeature.Contrib.Providers.Statsig
@@ -14,6 +15,7 @@ namespace OpenFeature.Contrib.Providers.Statsig
         internal const string CONTEXT_LOCALE = "locale";
         internal const string CONTEXT_USER_AGENT = "userAgent";
         internal const string CONTEXT_PRIVATE_ATTRIBUTES = "privateAttributes";
+        internal const string CONTEXT_CUSTOM_IDS = "customIDs";
 
         public static StatsigUser AsStatsigUser(this EvaluationContext evaluationContext)
         {
@@ -49,7 +51,19 @@ namespace OpenFeature.Contrib.Providers.Statsig
                             var privateAttributes = item.Value.AsStructure;
                             foreach (var items in privateAttributes)
                             {
-                                user.AddPrivateAttribute(items.Key, items.Value);
+                                user.AddPrivateAttribute(items.Key, items.Value.AsObject);
+                            }
+                        }
+                        break;
+                    case CONTEXT_CUSTOM_IDS:
+                        if (item.Value.IsStructure)
+                        {
+                            var customIds = item.Value.AsStructure;
+                            foreach (var items in customIds)
+                            {
+                                if (item.Value.IsString)
+                                    user.AddCustomID(items.Key, items.Value.AsString);
+                                else throw new FeatureProviderException(Constant.ErrorType.TypeMismatch, "Only string values are supported for CustomIDs");
                             }
                         }
                         break;

--- a/src/OpenFeature.Contrib.Providers.Statsig/OpenFeature.Contrib.Providers.Statsig.csproj
+++ b/src/OpenFeature.Contrib.Providers.Statsig/OpenFeature.Contrib.Providers.Statsig.csproj
@@ -4,7 +4,6 @@
 		<PackageId>OpenFeature.Contrib.Providers.Statsig</PackageId>
 		<VersionNumber>0.0.5</VersionNumber><!--x-release-please-version -->
 		<VersionPrefix>$(VersionNumber)</VersionPrefix>
-		<VersionSuffix>preview</VersionSuffix>
 		<AssemblyVersion>$(VersionNumber)</AssemblyVersion>
 		<FileVersion>$(VersionNumber)</FileVersion>
 		<Description>Statsig provider for .NET</Description>

--- a/test/OpenFeature.Contrib.Providers.Statsig.Test/EvaluationContextExtensionsTests.cs
+++ b/test/OpenFeature.Contrib.Providers.Statsig.Test/EvaluationContextExtensionsTests.cs
@@ -1,6 +1,7 @@
 using AutoFixture.Xunit2;
 using OpenFeature.Model;
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace OpenFeature.Contrib.Providers.Statsig.Test
@@ -80,7 +81,24 @@ namespace OpenFeature.Contrib.Providers.Statsig.Test
             // Assert
             Assert.NotNull(statsigUser);
             Assert.True(statsigUser.PrivateAttributes.TryGetValue(key, out var mappedValue));
-            Assert.Equal(value, (mappedValue as Value)?.AsString);
+            Assert.Equal(value, mappedValue);
+        }
+
+        [Theory]
+        [AutoData]
+        public void AsStatsigUser_ShouldMapCustomIds(Dictionary<string, string> customIdKeyValues)
+        {
+
+            // Arrange
+            var evaluationContext = EvaluationContext.Builder().Set(EvaluationContextExtensions.CONTEXT_CUSTOM_IDS, new Structure(customIdKeyValues.ToDictionary(kvp => kvp.Key, kvp => new Value(kvp.Value)))).Build();
+
+            // Act
+            var statsigUser = evaluationContext.AsStatsigUser();
+
+            // Assert
+            Assert.NotNull(statsigUser);
+            var result = statsigUser.CustomIDs.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            Assert.Equal(customIdKeyValues, result);
         }
 
         [Fact]

--- a/test/OpenFeature.Contrib.Providers.Statsig.Test/EvaluationContextExtensionsTests.cs
+++ b/test/OpenFeature.Contrib.Providers.Statsig.Test/EvaluationContextExtensionsTests.cs
@@ -1,6 +1,7 @@
 using AutoFixture.Xunit2;
 using OpenFeature.Model;
 using System.Collections.Generic;
+using System.Configuration.Provider;
 using System.Linq;
 using Xunit;
 
@@ -99,6 +100,17 @@ namespace OpenFeature.Contrib.Providers.Statsig.Test
             Assert.NotNull(statsigUser);
             var result = statsigUser.CustomIDs.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
             Assert.Equal(customIdKeyValues, result);
+        }
+
+        [Theory]
+        [AutoData]
+        public void AsStatsigUser_ShouldFailOnNonStringCustomId(Dictionary<string, int> customIdKeyValues)
+        {
+            // Arrange
+            var evaluationContext = EvaluationContext.Builder().Set(EvaluationContextExtensions.CONTEXT_CUSTOM_IDS, new Structure(customIdKeyValues.ToDictionary(kvp => kvp.Key, kvp => new Value(kvp.Value)))).Build();
+
+            // Act and Assert
+            Assert.Throws<ProviderException>(evaluationContext.AsStatsigUser);
         }
 
         [Fact]

--- a/test/OpenFeature.Contrib.Providers.Statsig.Test/EvaluationContextExtensionsTests.cs
+++ b/test/OpenFeature.Contrib.Providers.Statsig.Test/EvaluationContextExtensionsTests.cs
@@ -1,7 +1,7 @@
 using AutoFixture.Xunit2;
+using OpenFeature.Error;
 using OpenFeature.Model;
 using System.Collections.Generic;
-using System.Configuration.Provider;
 using System.Linq;
 using Xunit;
 
@@ -112,7 +112,7 @@ namespace OpenFeature.Contrib.Providers.Statsig.Test
             var evaluationContext = EvaluationContext.Builder().Set(EvaluationContextExtensions.CONTEXT_CUSTOM_IDS, customIdStructure).Build();
 
             // Act and Assert
-            Assert.Throws<ProviderException>(evaluationContext.AsStatsigUser);
+            Assert.Throws<FeatureProviderException>(evaluationContext.AsStatsigUser);
         }
 
         [Fact]

--- a/test/OpenFeature.Contrib.Providers.Statsig.Test/EvaluationContextExtensionsTests.cs
+++ b/test/OpenFeature.Contrib.Providers.Statsig.Test/EvaluationContextExtensionsTests.cs
@@ -91,7 +91,8 @@ namespace OpenFeature.Contrib.Providers.Statsig.Test
         {
 
             // Arrange
-            var evaluationContext = EvaluationContext.Builder().Set(EvaluationContextExtensions.CONTEXT_CUSTOM_IDS, new Structure(customIdKeyValues.ToDictionary(kvp => kvp.Key, kvp => new Value(kvp.Value)))).Build();
+            var customIdStructure = new Structure(customIdKeyValues.ToDictionary(kvp => kvp.Key, kvp => new Value(kvp.Value)));
+            var evaluationContext = EvaluationContext.Builder().Set(EvaluationContextExtensions.CONTEXT_CUSTOM_IDS, customIdStructure).Build();
 
             // Act
             var statsigUser = evaluationContext.AsStatsigUser();
@@ -107,7 +108,8 @@ namespace OpenFeature.Contrib.Providers.Statsig.Test
         public void AsStatsigUser_ShouldFailOnNonStringCustomId(Dictionary<string, int> customIdKeyValues)
         {
             // Arrange
-            var evaluationContext = EvaluationContext.Builder().Set(EvaluationContextExtensions.CONTEXT_CUSTOM_IDS, new Structure(customIdKeyValues.ToDictionary(kvp => kvp.Key, kvp => new Value(kvp.Value)))).Build();
+            var customIdStructure = new Structure(customIdKeyValues.ToDictionary(kvp => kvp.Key, kvp => new Value(kvp.Value)));
+            var evaluationContext = EvaluationContext.Builder().Set(EvaluationContextExtensions.CONTEXT_CUSTOM_IDS, customIdStructure).Build();
 
             // Act and Assert
             Assert.Throws<ProviderException>(evaluationContext.AsStatsigUser);


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
- adds mapping from [Evaluation Context](https://openfeature.dev/docs/reference/concepts/evaluation-context/) to [Statsig CustomID](https://docs.statsig.com/guides/experiment-on-custom-id-types).
- fixes dotnet format workflow so it uses `global.json` for dotnet version. Prior to this `.github/workflows/dotnet-format.yml` would fail when the dotnet version specified in `global.json` was greater than the one installed on the Github runner. 
- removes preview suffix from nuget package.

