### PR TITLE
fix: refactor OTEL metrics tests to make them more stable

### DIFF
--- a/test/OpenFeature.Contrib.Hooks.Otel.Test/MetricsHookTest.cs
+++ b/test/OpenFeature.Contrib.Hooks.Otel.Test/MetricsHookTest.cs
@@ -21,7 +21,7 @@ namespace OpenFeature.Contrib.Hooks.Otel.Test
             meterProvider = Sdk.CreateMeterProviderBuilder()
                 .AddMeter("*")
                 .ConfigureResource(r => r.AddService("openfeature"))
-                .AddInMemoryExporter(exportedItems, option => option.PeriodicExportingMetricReaderOptions = new PeriodicExportingMetricReaderOptions { ExportIntervalMilliseconds = 100 })
+                .AddInMemoryExporter(exportedItems)
                 .Build();
         }
 


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
- fixes the `MetricsHookTest` by using `MeterProvider.ForceFlush()` rather than waiting for periodic flush to happen

### Notes
The test in question would fail occasionally. This refactor will hopefully make them more stable, as there is the need to wait for an async process to complete has been removed.

