### PR TITLE
chore: add extra component owner for the Statsig provider

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -20,6 +20,7 @@ components:
     - toddbaert
   src/OpenFeature.Contrib.Providers.Statsig:
     - jenshenneberg
+    - lattenborough
 
   # test/
   test/OpenFeature.Contrib.Hooks.Otel.Test:
@@ -41,6 +42,7 @@ components:
     - toddbaert
   test/src/OpenFeature.Contrib.Providers.Statsig.Test:
     - jenshenneberg
+    - lattenborough
 
 ignored-authors:
   - renovate-bot


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
- adds @LAttenborough as a component owner for the Statsig provider

