### PR TITLE
fix: remove Microsoft.Extensions.Logging from flagd provider

### DIFF
--- a/src/OpenFeature.Contrib.Providers.Flagd/OpenFeature.Contrib.Providers.Flagd.csproj
+++ b/src/OpenFeature.Contrib.Providers.Flagd/OpenFeature.Contrib.Providers.Flagd.csproj
@@ -23,9 +23,6 @@
     <!-- The schema.proto file referenced here will be used to automatically generate the Grpc client when executing 'dotnet build' -->
     <!-- The generated files will be placed in ./obj/Debug/netstandard2.0/Protos -->
     <PackageReference Include="JsonLogic.Net" Version="1.1.11" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
     <PackageReference Include="murmurhash" Version="1.0.3" />
     <PackageReference Include="Semver" Version="2.3.0" />
     <Protobuf Include="schemas\protobuf\flagd\evaluation\v1\evaluation.proto" GrpcServices="Client" />

--- a/src/OpenFeature.Contrib.Providers.Flagd/Resolver/InProcess/CustomEvaluators/FractionalEvaluator.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/Resolver/InProcess/CustomEvaluators/FractionalEvaluator.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using JsonLogic.Net;
-using Microsoft.Extensions.Logging;
 using Murmur;
 using Newtonsoft.Json.Linq;
 using Semver;
@@ -13,21 +12,8 @@ namespace OpenFeature.Contrib.Providers.Flagd.Resolver.InProcess.CustomEvaluator
     /// <inheritdoc/>
     public class FractionalEvaluator
     {
-
-        internal ILogger Logger { get; set; }
-
         internal FractionalEvaluator()
         {
-            var loggerFactory = LoggerFactory.Create(
-                builder => builder
-                    // add console as logging target
-                    .AddConsole()
-                    // add debug output as logging target
-                    .AddDebug()
-                    // set minimum level to log
-                    .SetMinimumLevel(LogLevel.Debug)
-                );
-            Logger = loggerFactory.CreateLogger<FractionalEvaluator>();
         }
 
         class FractionalEvaluationDistribution
@@ -118,7 +104,6 @@ namespace OpenFeature.Contrib.Providers.Flagd.Resolver.InProcess.CustomEvaluator
                 }
             }
 
-            Logger.LogDebug("No matching bucket found");
             return "";
         }
     }

--- a/src/OpenFeature.Contrib.Providers.Flagd/Resolver/InProcess/CustomEvaluators/StringEvaluator.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/Resolver/InProcess/CustomEvaluators/StringEvaluator.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
 using JsonLogic.Net;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Newtonsoft.Json.Linq;
 using OpenFeature.Error;
 using OpenFeature.Model;
@@ -11,20 +9,8 @@ namespace OpenFeature.Contrib.Providers.Flagd.Resolver.InProcess.CustomEvaluator
 {
     internal class StringEvaluator
     {
-        internal ILogger Logger { get; set; }
-
         internal StringEvaluator()
         {
-            var loggerFactory = LoggerFactory.Create(
-                builder => builder
-                    // add console as logging target
-                    .AddConsole()
-                    // add debug output as logging target
-                    .AddDebug()
-                    // set minimum level to log
-                    .SetMinimumLevel(LogLevel.Debug)
-                );
-            Logger = loggerFactory.CreateLogger<StringEvaluator>();
         }
 
         internal object StartsWith(IProcessJsonLogic p, JToken[] args, object data)


### PR DESCRIPTION
## This PR
- Remove `Microsoft.Extensions.Logging` dependencies from `OpenFeature.Contrib.Providers.Flagd`
- Use `SemVersion.TryParse` to avoid a throw and catch

### Related Issues

Fixes #232