### PR TITLE
ci: add adams85 from ConfigCat as component owner

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -15,6 +15,7 @@ components:
     - matthewelwell
   src/OpenFeature.Contrib.Providers.ConfigCat:
     - luizbon
+    - adams85
   src/OpenFeature.Contrib.Providers.FeatureManagement:
     - ericpattison
     - toddbaert
@@ -37,6 +38,7 @@ components:
     - matthewelwell
   test/OpenFeature.Contrib.Providers.ConfigCat.Test:
     - luizbon
+    - adams85
   test/OpenFeature.Contrib.Providers.FeatureManagement.Test:
     - ericpattison
     - toddbaert


### PR DESCRIPTION
## This PR

- Adds @adams85 (ConfigCat) to the component owner's list of the ConfigCat provider. The intention behind this is that we (ConfigCat) would like to mark the provider in this repo as the official ConfigCat OpenFeature .NET provider, and we would like to participate in its development and maintenance.

