### PR TITLE
chore: update OpenFeature version compatiblity

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -23,8 +23,8 @@
       Please sort alphabetically.
       Refer to https://docs.microsoft.com/nuget/concepts/package-versioning for semver syntax.
     -->
-    <!-- 1.5+ -->
-    <OpenFeatureVer>[1.5,)</OpenFeatureVer>
+    <!-- 1.5-1.9999 -->
+    <OpenFeatureVer>(1.5,2.0)</OpenFeatureVer>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(OS)' == 'Unix'">

--- a/src/OpenFeature.Contrib.Hooks.Otel/README.md
+++ b/src/OpenFeature.Contrib.Hooks.Otel/README.md
@@ -1,8 +1,8 @@
 # OpenFeature OpenTelemetry hook for .NET
 
-### Requirements
+## Requirements
 
-- open-feature/dotnet-sdk >= v1.0
+- open-feature/dotnet-sdk v1.5 > v2.0
 
 ## Usage - Traces
 

--- a/src/OpenFeature.Contrib.Providers.ConfigCat/README.md
+++ b/src/OpenFeature.Contrib.Providers.ConfigCat/README.md
@@ -4,6 +4,10 @@ The ConfigCat Flag provider allows you to connect to your ConfigCat instance.
 
 # .Net SDK usage
 
+## Requirements
+
+- open-feature/dotnet-sdk v1.5 > v2.0
+
 ## Install dependencies
 
 The first things we will do is install the **Open Feature SDK** and the **ConfigCat Feature Flag provider**.

--- a/src/OpenFeature.Contrib.Providers.FeatureManagement/README.md
+++ b/src/OpenFeature.Contrib.Providers.FeatureManagement/README.md
@@ -4,6 +4,10 @@
 
 The FeatureManagement Provider allows you to use the FeatureManagement system as an OpenFeature Provider.
 
+## Requirements
+
+- open-feature/dotnet-sdk v1.5 > v2.0
+
 ## .NET SDK Usage
 
 ### Install dependencies

--- a/src/OpenFeature.Contrib.Providers.Flagd/README.md
+++ b/src/OpenFeature.Contrib.Providers.Flagd/README.md
@@ -4,6 +4,10 @@ The flagd Flag provider allows you to connect to your flagd instance.
 
 # .Net SDK usage
 
+## Requirements
+
+- open-feature/dotnet-sdk v1.5 > v2.0
+
 ## Install dependencies
 
 We will first install the **OpenFeature SDK** and the **flagd provider**.

--- a/src/OpenFeature.Contrib.Providers.Flagsmith/README.md
+++ b/src/OpenFeature.Contrib.Providers.Flagsmith/README.md
@@ -4,6 +4,10 @@ The Flagsmith provider allows you to connect to your Flagsmith instance through 
 
 # .Net SDK usage
 
+## Requirements
+
+- open-feature/dotnet-sdk v1.5 > v2.0
+
 ## Install dependencies
 
 The first things we will do is install the **Open Feature SDK** and the **Flagsmith Feature Flag provider**.

--- a/src/OpenFeature.Contrib.Providers.GOFeatureFlag/README.md
+++ b/src/OpenFeature.Contrib.Providers.GOFeatureFlag/README.md
@@ -9,6 +9,10 @@ This is a complete feature flagging solution with the possibility to target only
 
 # .Net SDK usage
 
+## Requirements
+
+- open-feature/dotnet-sdk v1.5 > v2.0
+
 ## Install dependencies
 
 The first things we will do is install the **Open Feature SDK** and the **GO Feature Flag provider**.

--- a/src/OpenFeature.Contrib.Providers.Statsig/README.md
+++ b/src/OpenFeature.Contrib.Providers.Statsig/README.md
@@ -4,6 +4,10 @@ The Statsig Flag provider allows you to connect to Statsig. Please note this is 
 
 # .Net SDK usage
 
+## Requirements
+
+- open-feature/dotnet-sdk v1.5 > v2.0
+
 ## Install dependencies
 
 The first things we will do is install the **Open Feature SDK** and the **Statsig Feature Flag provider**.


### PR DESCRIPTION
Updates the shared `OpenFeatureVer` to be less than 2.0, in preparation for our upcoming 2.0 release.

It would have been nice to have this from the get-go, but doing this now will help. I will subsequently release all artifacts.
Immediately after the 2.0 release I will update the contribs, and re-release with 2.0-3.0 compatibility.

see: https://learn.microsoft.com/en-us/nuget/concepts/package-versioning?tabs=semver20sort