### PR TITLE
feat!: use (and require) OpenFeature SDK v2

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -23,8 +23,8 @@
       Please sort alphabetically.
       Refer to https://docs.microsoft.com/nuget/concepts/package-versioning for semver syntax.
     -->
-    <!-- 1.5-1.9999 -->
-    <OpenFeatureVer>[1.5,2.0)</OpenFeatureVer>
+    <!-- 2.0-2.9999 -->
+    <OpenFeatureVer>[2.0,3.0)</OpenFeatureVer>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(OS)' == 'Unix'">

--- a/src/OpenFeature.Contrib.Hooks.Otel/MetricsHook.cs
+++ b/src/OpenFeature.Contrib.Hooks.Otel/MetricsHook.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using OpenFeature.Model;
 
@@ -36,17 +37,8 @@ namespace OpenFeature.Contrib.Hooks.Otel
             _evaluationErrorCounter = meter.CreateCounter<long>(MetricsConstants.ErrorTotalName, description: MetricsConstants.ErrorDescription);
         }
 
-        /// <summary>
-        /// Executes before the flag evaluation and captures metrics related to the evaluation.
-        /// The metrics are captured in the following order:
-        /// 1. The active count is incremented. (feature_flag.evaluation_active_count)
-        /// 2. The request count is incremented. (feature_flag.evaluation_requests_total)
-        /// </summary>
-        /// <typeparam name="T">The type of the flag value.</typeparam>
-        /// <param name="context">The hook context.</param>
-        /// <param name="hints">The optional hints.</param>
-        /// <returns>The evaluation context.</returns>
-        public override Task<EvaluationContext> Before<T>(HookContext<T> context, IReadOnlyDictionary<string, object> hints = null)
+        /// <inheritdoc/>
+        public override ValueTask<EvaluationContext> BeforeAsync<T>(HookContext<T> context, IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
         {
             var tagList = new TagList
             {
@@ -57,21 +49,12 @@ namespace OpenFeature.Contrib.Hooks.Otel
             _evaluationActiveUpDownCounter.Add(1, tagList);
             _evaluationRequestCounter.Add(1, tagList);
 
-            return base.Before(context, hints);
+            return base.BeforeAsync(context, hints);
         }
 
 
-        /// <summary>
-        /// Executes after the flag evaluation and captures metrics related to the evaluation.
-        /// The metrics are captured in the following order:
-        /// 1. The success count is incremented. (feature_flag.evaluation_success_total)
-        /// </summary>
-        /// <typeparam name="T">The type of the flag value.</typeparam>
-        /// <param name="context">The hook context.</param>
-        /// <param name="details">The flag evaluation details.</param>
-        /// <param name="hints">The optional hints.</param>
-        /// <returns>The evaluation context.</returns>
-        public override Task After<T>(HookContext<T> context, FlagEvaluationDetails<T> details, IReadOnlyDictionary<string, object> hints = null)
+        /// <inheritdoc/>
+        public override ValueTask AfterAsync<T>(HookContext<T> context, FlagEvaluationDetails<T> details, IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
         {
             var tagList = new TagList
             {
@@ -83,20 +66,11 @@ namespace OpenFeature.Contrib.Hooks.Otel
 
             _evaluationSuccessCounter.Add(1, tagList);
 
-            return base.After(context, details, hints);
+            return base.AfterAsync(context, details, hints);
         }
 
-        /// <summary>
-        /// Executes when an error occurs during flag evaluation and captures metrics related to the error.
-        /// The metrics are captured in the following order:
-        /// 1. The error count is incremented. (feature_flag.evaluation_error_total)
-        /// </summary>
-        /// <typeparam name="T">The type of the flag value.</typeparam>
-        /// <param name="context">The hook context.</param>
-        /// <param name="error">The exception that occurred.</param>
-        /// <param name="hints">The optional hints.</param>
-        /// <returns>The evaluation context.</returns>
-        public override Task Error<T>(HookContext<T> context, Exception error, IReadOnlyDictionary<string, object> hints = null)
+        /// <inheritdoc/>
+        public override ValueTask ErrorAsync<T>(HookContext<T> context, Exception error, IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
         {
             var tagList = new TagList
             {
@@ -107,18 +81,11 @@ namespace OpenFeature.Contrib.Hooks.Otel
 
             _evaluationErrorCounter.Add(1, tagList);
 
-            return base.Error(context, error, hints);
+            return base.ErrorAsync(context, error, hints);
         }
 
-        /// <summary>
-        /// Executes after the flag evaluation is complete and captures metrics related to the evaluation.
-        /// The active count is decremented. (feature_flag.evaluation_active_count)
-        /// </summary>
-        /// <typeparam name="T">The type of the flag value.</typeparam>
-        /// <param name="context">The hook context.</param>
-        /// <param name="hints">The optional hints.</param>
-        /// <returns>The evaluation context.</returns>
-        public override Task Finally<T>(HookContext<T> context, IReadOnlyDictionary<string, object> hints = null)
+        /// <inheritdoc/>
+        public override ValueTask FinallyAsync<T>(HookContext<T> context, IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
         {
             var tagList = new TagList
             {
@@ -128,7 +95,7 @@ namespace OpenFeature.Contrib.Hooks.Otel
 
             _evaluationActiveUpDownCounter.Add(-1, tagList);
 
-            return base.Finally(context, hints);
+            return base.FinallyAsync(context, hints);
         }
     }
 }

--- a/src/OpenFeature.Contrib.Hooks.Otel/OtelHook.cs
+++ b/src/OpenFeature.Contrib.Hooks.Otel/OtelHook.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System;
+using System.Threading;
 
 namespace OpenFeature.Contrib.Hooks.Otel
 
@@ -16,34 +17,22 @@ namespace OpenFeature.Contrib.Hooks.Otel
     {
         private readonly TracingHook _tracingHook = new TracingHook();
 
-        /// <summary>
-        ///     After is executed after a feature flag has been evaluated.
-        /// </summary>
-        /// <param name="context">The hook context</param>
-        /// <param name="details">The result of the feature flag evaluation</param>
-        /// <param name="hints">Hints for the feature flag evaluation</param>
-        /// <returns>An awaitable Task object</returns>
-        public override Task After<T>(HookContext<T> context, FlagEvaluationDetails<T> details,
-            IReadOnlyDictionary<string, object> hints = null)
+        /// <inheritdoc/>
+        public override ValueTask AfterAsync<T>(HookContext<T> context, FlagEvaluationDetails<T> details,
+            IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
         {
-            _tracingHook.After(context, details, hints);
+            _tracingHook.AfterAsync(context, details, hints);
 
-            return Task.CompletedTask;
+            return default;
         }
 
-        /// <summary>
-        ///     Error is executed when an error during a feature flag evaluation occured.
-        /// </summary>
-        /// <param name="context">The hook context</param>
-        /// <param name="error">The exception thrown by feature flag provider</param>
-        /// <param name="hints">Hints for the feature flag evaluation</param>
-        /// <returns>An awaitable Task object</returns>
-        public override Task Error<T>(HookContext<T> context, System.Exception error,
-            IReadOnlyDictionary<string, object> hints = null)
+        /// <inheritdoc/>
+        public override ValueTask ErrorAsync<T>(HookContext<T> context, System.Exception error,
+            IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
         {
-            _tracingHook.Error(context, error, hints);
+            _tracingHook.ErrorAsync(context, error, hints);
 
-            return Task.CompletedTask;
+            return default;
         }
 
     }

--- a/src/OpenFeature.Contrib.Hooks.Otel/README.md
+++ b/src/OpenFeature.Contrib.Hooks.Otel/README.md
@@ -48,7 +48,7 @@ namespace OpenFeatureTestApp
 
             var client = OpenFeature.Api.Instance.GetClient("my-app");
 
-            var val = client.GetBooleanValue("myBoolFlag", false, null);
+            var val = client.GetBooleanValueAsync("myBoolFlag", false, null);
 
             // Print the value of the 'myBoolFlag' feature flag
             System.Console.WriteLine(val.Result.ToString());
@@ -114,7 +114,7 @@ namespace OpenFeatureTestApp
 
             var client = OpenFeature.Api.Instance.GetClient("my-app");
 
-            var val = client.GetBooleanValue("myBoolFlag", false, null);
+            var val = client.GetBooleanValueAsync("myBoolFlag", false, null);
 
             // Print the value of the 'myBoolFlag' feature flag
             System.Console.WriteLine(val.Result.ToString());

--- a/src/OpenFeature.Contrib.Hooks.Otel/TracingHook.cs
+++ b/src/OpenFeature.Contrib.Hooks.Otel/TracingHook.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Diagnostics;
 using OpenTelemetry.Trace;
+using System.Threading;
 
 namespace OpenFeature.Contrib.Hooks.Otel
 
@@ -13,15 +14,9 @@ namespace OpenFeature.Contrib.Hooks.Otel
     public class TracingHook : Hook
     {
 
-        /// <summary>
-        ///     After is executed after a feature flag has been evaluated.
-        /// </summary>
-        /// <param name="context">The hook context</param>
-        /// <param name="details">The result of the feature flag evaluation</param>
-        /// <param name="hints">Hints for the feature flag evaluation</param>
-        /// <returns>An awaitable Task object</returns>
-        public override Task After<T>(HookContext<T> context, FlagEvaluationDetails<T> details,
-            IReadOnlyDictionary<string, object> hints = null)
+        /// <inheritdoc/>
+        public override ValueTask AfterAsync<T>(HookContext<T> context, FlagEvaluationDetails<T> details,
+            IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
         {
             Activity.Current?
                 .SetTag("feature_flag.key", details.FlagKey)
@@ -34,22 +29,16 @@ namespace OpenFeature.Contrib.Hooks.Otel
                     ["feature_flag.provider_name"] = context.ProviderMetadata.Name
                 }));
 
-            return Task.CompletedTask;
+            return default;
         }
 
-        /// <summary>
-        ///     Error is executed when an error during a feature flag evaluation occured.
-        /// </summary>
-        /// <param name="context">The hook context</param>
-        /// <param name="error">The exception thrown by feature flag provider</param>
-        /// <param name="hints">Hints for the feature flag evaluation</param>
-        /// <returns>An awaitable Task object</returns>
-        public override Task Error<T>(HookContext<T> context, System.Exception error,
-            IReadOnlyDictionary<string, object> hints = null)
+        /// <inheritdoc/>
+        public override ValueTask ErrorAsync<T>(HookContext<T> context, System.Exception error,
+            IReadOnlyDictionary<string, object> hints = null, CancellationToken cancellationToken = default)
         {
             Activity.Current?.RecordException(error);
 
-            return Task.CompletedTask;
+            return default;
         }
 
     }

--- a/src/OpenFeature.Contrib.Providers.ConfigCat/ConfigCatProvider.cs
+++ b/src/OpenFeature.Contrib.Providers.ConfigCat/ConfigCatProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using ConfigCat.Client;
 using ConfigCat.Client.Configuration;
@@ -35,31 +36,31 @@ namespace OpenFeature.Contrib.ConfigCat
         }
 
         /// <inheritdoc/>
-        public override Task<ResolutionDetails<bool>> ResolveBooleanValue(string flagKey, bool defaultValue, EvaluationContext context = null)
+        public override Task<ResolutionDetails<bool>> ResolveBooleanValueAsync(string flagKey, bool defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
             return ResolveFlag(flagKey, context, defaultValue);
         }
 
         /// <inheritdoc/>
-        public override Task<ResolutionDetails<string>> ResolveStringValue(string flagKey, string defaultValue, EvaluationContext context = null)
+        public override Task<ResolutionDetails<string>> ResolveStringValueAsync(string flagKey, string defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
             return ResolveFlag(flagKey, context, defaultValue);
         }
 
         /// <inheritdoc/>
-        public override Task<ResolutionDetails<int>> ResolveIntegerValue(string flagKey, int defaultValue, EvaluationContext context = null)
+        public override Task<ResolutionDetails<int>> ResolveIntegerValueAsync(string flagKey, int defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
             return ResolveFlag(flagKey, context, defaultValue);
         }
 
         /// <inheritdoc/>
-        public override Task<ResolutionDetails<double>> ResolveDoubleValue(string flagKey, double defaultValue, EvaluationContext context = null)
+        public override Task<ResolutionDetails<double>> ResolveDoubleValueAsync(string flagKey, double defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
             return ResolveFlag(flagKey, context, defaultValue);
         }
 
         /// <inheritdoc/>
-        public override async Task<ResolutionDetails<Value>> ResolveStructureValue(string flagKey, Value defaultValue, EvaluationContext context = null)
+        public override async Task<ResolutionDetails<Value>> ResolveStructureValueAsync(string flagKey, Value defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
             var user = context?.BuildUser();
             var result = await Client.GetValueDetailsAsync(flagKey, defaultValue?.AsObject, user);

--- a/src/OpenFeature.Contrib.Providers.ConfigCat/ConfigCatProvider.cs
+++ b/src/OpenFeature.Contrib.Providers.ConfigCat/ConfigCatProvider.cs
@@ -38,32 +38,32 @@ namespace OpenFeature.Contrib.ConfigCat
         /// <inheritdoc/>
         public override Task<ResolutionDetails<bool>> ResolveBooleanValueAsync(string flagKey, bool defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
-            return ResolveFlag(flagKey, context, defaultValue);
+            return ResolveFlag(flagKey, context, defaultValue, cancellationToken);
         }
 
         /// <inheritdoc/>
         public override Task<ResolutionDetails<string>> ResolveStringValueAsync(string flagKey, string defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
-            return ResolveFlag(flagKey, context, defaultValue);
+            return ResolveFlag(flagKey, context, defaultValue, cancellationToken);
         }
 
         /// <inheritdoc/>
         public override Task<ResolutionDetails<int>> ResolveIntegerValueAsync(string flagKey, int defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
-            return ResolveFlag(flagKey, context, defaultValue);
+            return ResolveFlag(flagKey, context, defaultValue, cancellationToken);
         }
 
         /// <inheritdoc/>
         public override Task<ResolutionDetails<double>> ResolveDoubleValueAsync(string flagKey, double defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
-            return ResolveFlag(flagKey, context, defaultValue);
+            return ResolveFlag(flagKey, context, defaultValue, cancellationToken);
         }
 
         /// <inheritdoc/>
         public override async Task<ResolutionDetails<Value>> ResolveStructureValueAsync(string flagKey, Value defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
             var user = context?.BuildUser();
-            var result = await Client.GetValueDetailsAsync(flagKey, defaultValue?.AsObject, user);
+            var result = await Client.GetValueDetailsAsync(flagKey, defaultValue?.AsObject, user, cancellationToken);
             var returnValue = result.IsDefaultValue ? defaultValue : new Value(result.Value);
             var details = new ResolutionDetails<Value>(flagKey, returnValue, TranslateErrorCode(result.ErrorCode), errorMessage: result.ErrorMessage, variant: result.VariationId);
             if (details.ErrorType == ErrorType.None)
@@ -74,10 +74,10 @@ namespace OpenFeature.Contrib.ConfigCat
             throw new FeatureProviderException(details.ErrorType, details.ErrorMessage);
         }
 
-        private async Task<ResolutionDetails<T>> ResolveFlag<T>(string flagKey, EvaluationContext context, T defaultValue)
+        private async Task<ResolutionDetails<T>> ResolveFlag<T>(string flagKey, EvaluationContext context, T defaultValue, CancellationToken cancellationToken)
         {
             var user = context?.BuildUser();
-            var result = await Client.GetValueDetailsAsync(flagKey, defaultValue, user);
+            var result = await Client.GetValueDetailsAsync(flagKey, defaultValue, user, cancellationToken);
             var details = new ResolutionDetails<T>(flagKey, result.Value, TranslateErrorCode(result.ErrorCode), errorMessage: result.ErrorMessage, variant: result.VariationId);
             if (details.ErrorType == ErrorType.None)
             {

--- a/src/OpenFeature.Contrib.Providers.ConfigCat/README.md
+++ b/src/OpenFeature.Contrib.Providers.ConfigCat/README.md
@@ -60,7 +60,7 @@ namespace OpenFeatureTestApp
 
             var client = OpenFeature.Api.Instance.GetClient();
 
-            var val = client.GetBooleanValue("isMyAwesomeFeatureEnabled", false);
+            var val = client.GetBooleanValueAsync("isMyAwesomeFeatureEnabled", false);
 
             if(isMyAwesomeFeatureEnabled)
             {

--- a/src/OpenFeature.Contrib.Providers.FeatureManagement/FeatureManagementProvider.cs
+++ b/src/OpenFeature.Contrib.Providers.FeatureManagement/FeatureManagementProvider.cs
@@ -46,7 +46,7 @@ namespace OpenFeature.Contrib.Providers.FeatureManagement
         public override Metadata GetMetadata() => metadata;
 
         /// <inheritdoc />
-        public override async Task<ResolutionDetails<bool>> ResolveBooleanValue(string flagKey, bool defaultValue, EvaluationContext context = null)
+        public override async Task<ResolutionDetails<bool>> ResolveBooleanValueAsync(string flagKey, bool defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
             var variant = await Evaluate(flagKey, context, CancellationToken.None);
 
@@ -56,7 +56,7 @@ namespace OpenFeature.Contrib.Providers.FeatureManagement
         }
 
         /// <inheritdoc />
-        public override async Task<ResolutionDetails<double>> ResolveDoubleValue(string flagKey, double defaultValue, EvaluationContext context = null)
+        public override async Task<ResolutionDetails<double>> ResolveDoubleValueAsync(string flagKey, double defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
             var variant = await Evaluate(flagKey, context, CancellationToken.None);
 
@@ -67,7 +67,7 @@ namespace OpenFeature.Contrib.Providers.FeatureManagement
         }
 
         /// <inheritdoc />
-        public override async Task<ResolutionDetails<int>> ResolveIntegerValue(string flagKey, int defaultValue, EvaluationContext context = null)
+        public override async Task<ResolutionDetails<int>> ResolveIntegerValueAsync(string flagKey, int defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
             var variant = await Evaluate(flagKey, context, CancellationToken.None);
 
@@ -78,7 +78,7 @@ namespace OpenFeature.Contrib.Providers.FeatureManagement
         }
 
         /// <inheritdoc />
-        public override async Task<ResolutionDetails<string>> ResolveStringValue(string flagKey, string defaultValue, EvaluationContext context = null)
+        public override async Task<ResolutionDetails<string>> ResolveStringValueAsync(string flagKey, string defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
             var variant = await Evaluate(flagKey, context, CancellationToken.None);
 
@@ -89,7 +89,7 @@ namespace OpenFeature.Contrib.Providers.FeatureManagement
         }
 
         /// <inheritdoc />
-        public override async Task<ResolutionDetails<Value>> ResolveStructureValue(string flagKey, Value defaultValue, EvaluationContext context = null)
+        public override async Task<ResolutionDetails<Value>> ResolveStructureValueAsync(string flagKey, Value defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
             var variant = await Evaluate(flagKey, context, CancellationToken.None);
 

--- a/src/OpenFeature.Contrib.Providers.FeatureManagement/README.md
+++ b/src/OpenFeature.Contrib.Providers.FeatureManagement/README.md
@@ -70,7 +70,7 @@ namespace OpenFeatureTestApp
 
             var client = OpenFeature.Api.Instance.GetClient();
 
-            var val = await client.GetBooleanValue("myBoolFlag", false, null);
+            var val = await client.GetBooleanValueAsync("myBoolFlag", false, null);
 
             System.Console.WriteLine(val.ToString());
         }

--- a/src/OpenFeature.Contrib.Providers.Flagd/FlagdProvider.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/FlagdProvider.cs
@@ -7,6 +7,7 @@ using Metadata = OpenFeature.Model.Metadata;
 using Value = OpenFeature.Model.Value;
 using OpenFeature.Constant;
 using System.Diagnostics.Tracing;
+using System.Threading;
 
 namespace OpenFeature.Contrib.Providers.Flagd
 {
@@ -17,9 +18,7 @@ namespace OpenFeature.Contrib.Providers.Flagd
     {
         const string ProviderName = "flagd Provider";
         private readonly FlagdConfig _config;
-        private ProviderStatus _status = ProviderStatus.NotReady;
         private readonly Metadata _providerMetadata = new Metadata(ProviderName);
-
         private readonly Resolver.Resolver _resolver;
 
         /// <summary>
@@ -85,12 +84,6 @@ namespace OpenFeature.Contrib.Providers.Flagd
             _resolver.Init();
         }
 
-        /// <inheritdoc/>
-        public override ProviderStatus GetStatus()
-        {
-            return _status;
-        }
-
         // just for testing, internal but visible in tests
         internal FlagdConfig GetConfig() => _config;
 
@@ -113,91 +106,58 @@ namespace OpenFeature.Contrib.Providers.Flagd
         internal Resolver.Resolver GetResolver() => _resolver;
 
         /// <inheritdoc/>
-        public override Task Initialize(EvaluationContext context)
+        public override Task InitializeAsync(EvaluationContext context, CancellationToken cancellationToken = default)
         {
             return Task.Run(async () =>
             {
                 await _resolver.Init();
-                _status = ProviderStatus.Ready;
             }).ContinueWith((t) =>
             {
                 if (t.IsFaulted)
                 {
-                    _status = ProviderStatus.Error;
                     throw t.Exception;
                 };
             });
         }
 
         /// <inheritdoc/>
-        public override Task Shutdown()
+        public override Task ShutdownAsync(CancellationToken cancellationToken = default)
         {
             return _resolver.Shutdown().ContinueWith((t) =>
             {
-                _status = ProviderStatus.NotReady;
                 if (t.IsFaulted) throw t.Exception;
             });
         }
 
-        /// <summary>
-        ///     ResolveBooleanValue resolve the value for a Boolean Flag.
-        /// </summary>
-        /// <param name="flagKey">Name of the flag</param>
-        /// <param name="defaultValue">Default value used in case of error.</param>
-        /// <param name="context">Context about the user</param>
-        /// <returns>A ResolutionDetails object containing the value of your flag</returns>
-        public override async Task<ResolutionDetails<bool>> ResolveBooleanValue(string flagKey, bool defaultValue, EvaluationContext context = null)
+        /// <inheritdoc/>
+        public override async Task<ResolutionDetails<bool>> ResolveBooleanValueAsync(string flagKey, bool defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
-            return await _resolver.ResolveBooleanValue(flagKey, defaultValue, context).ConfigureAwait(false);
+            return await _resolver.ResolveBooleanValueAsync(flagKey, defaultValue, context).ConfigureAwait(false);
         }
 
-        /// <summary>
-        ///     ResolveStringValue resolve the value for a string Flag.
-        /// </summary>
-        /// <param name="flagKey">Name of the flag</param>
-        /// <param name="defaultValue">Default value used in case of error.</param>
-        /// <param name="context">Context about the user</param>
-        /// <returns>A ResolutionDetails object containing the value of your flag</returns>
-        public override async Task<ResolutionDetails<string>> ResolveStringValue(string flagKey, string defaultValue, EvaluationContext context = null)
+        /// <inheritdoc/>
+        public override async Task<ResolutionDetails<string>> ResolveStringValueAsync(string flagKey, string defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
-            return await _resolver.ResolveStringValue(flagKey, defaultValue, context).ConfigureAwait(false);
+            return await _resolver.ResolveStringValueAsync(flagKey, defaultValue, context).ConfigureAwait(false);
         }
 
-        /// <summary>
-        ///     ResolveIntegerValue resolve the value for an int Flag.
-        /// </summary>
-        /// <param name="flagKey">Name of the flag</param>
-        /// <param name="defaultValue">Default value used in case of error.</param>
-        /// <param name="context">Context about the user</param>
-        /// <returns>A ResolutionDetails object containing the value of your flag</returns>
-        public override async Task<ResolutionDetails<int>> ResolveIntegerValue(string flagKey, int defaultValue, EvaluationContext context = null)
+        /// <inheritdoc/>
+        public override async Task<ResolutionDetails<int>> ResolveIntegerValueAsync(string flagKey, int defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
 
-            return await _resolver.ResolveIntegerValue(flagKey, defaultValue, context).ConfigureAwait(false);
+            return await _resolver.ResolveIntegerValueAsync(flagKey, defaultValue, context).ConfigureAwait(false);
         }
 
-        /// <summary>
-        ///     ResolveDoubleValue resolve the value for a double Flag.
-        /// </summary>
-        /// <param name="flagKey">Name of the flag</param>
-        /// <param name="defaultValue">Default value used in case of error.</param>
-        /// <param name="context">Context about the user</param>
-        /// <returns>A ResolutionDetails object containing the value of your flag</returns>
-        public override async Task<ResolutionDetails<double>> ResolveDoubleValue(string flagKey, double defaultValue, EvaluationContext context = null)
+        /// <inheritdoc/>
+        public override async Task<ResolutionDetails<double>> ResolveDoubleValueAsync(string flagKey, double defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
-            return await _resolver.ResolveDoubleValue(flagKey, defaultValue, context).ConfigureAwait(false);
+            return await _resolver.ResolveDoubleValueAsync(flagKey, defaultValue, context).ConfigureAwait(false);
         }
 
-        /// <summary>
-        ///     ResolveStructureValue resolve the value for a Boolean Flag.
-        /// </summary>
-        /// <param name="flagKey">Name of the flag</param>
-        /// <param name="defaultValue">Default value used in case of error.</param>
-        /// <param name="context">Context about the user</param>
-        /// <returns>A ResolutionDetails object containing the value of your flag</returns>
-        public override async Task<ResolutionDetails<Value>> ResolveStructureValue(string flagKey, Value defaultValue, EvaluationContext context = null)
+        /// <inheritdoc/>
+        public override async Task<ResolutionDetails<Value>> ResolveStructureValueAsync(string flagKey, Value defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
-            return await _resolver.ResolveStructureValue(flagKey, defaultValue, context).ConfigureAwait(false);
+            return await _resolver.ResolveStructureValueAsync(flagKey, defaultValue, context).ConfigureAwait(false);
         }
     }
 }

--- a/src/OpenFeature.Contrib.Providers.Flagd/README.md
+++ b/src/OpenFeature.Contrib.Providers.Flagd/README.md
@@ -67,7 +67,7 @@ namespace OpenFeatureTestApp
 
             var client = OpenFeature.Api.Instance.GetClient("my-app");
 
-            var val = client.GetBooleanValue("myBoolFlag", false, null);
+            var val = client.GetBooleanValueAsync("myBoolFlag", false, null);
 
             // Print the value of the 'myBoolFlag' feature flag
             System.Console.WriteLine(val.Result.ToString());
@@ -151,7 +151,7 @@ namespace OpenFeatureTestApp
 
             var client = OpenFeature.Api.Instance.GetClient("my-app");
 
-            var val = client.GetBooleanValue("myBoolFlag", false, null);
+            var val = client.GetBooleanValueAsync("myBoolFlag", false, null);
 
             // Print the value of the 'myBoolFlag' feature flag
             System.Console.WriteLine(val.Result.ToString());

--- a/src/OpenFeature.Contrib.Providers.Flagd/Resolver/InProcess/InProcessResolver.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/Resolver/InProcess/InProcessResolver.cs
@@ -76,29 +76,29 @@ namespace OpenFeature.Contrib.Providers.Flagd.Resolver.InProcess
             });
         }
 
-        public Task<ResolutionDetails<bool>> ResolveBooleanValue(string flagKey, bool defaultValue, EvaluationContext context = null)
+        public Task<ResolutionDetails<bool>> ResolveBooleanValueAsync(string flagKey, bool defaultValue, EvaluationContext context = null)
         {
-            return Task.FromResult(_evaluator.ResolveBooleanValue(flagKey, defaultValue, context));
+            return Task.FromResult(_evaluator.ResolveBooleanValueAsync(flagKey, defaultValue, context));
         }
 
-        public Task<ResolutionDetails<string>> ResolveStringValue(string flagKey, string defaultValue, EvaluationContext context = null)
+        public Task<ResolutionDetails<string>> ResolveStringValueAsync(string flagKey, string defaultValue, EvaluationContext context = null)
         {
-            return Task.FromResult(_evaluator.ResolveStringValue(flagKey, defaultValue, context));
+            return Task.FromResult(_evaluator.ResolveStringValueAsync(flagKey, defaultValue, context));
         }
 
-        public Task<ResolutionDetails<int>> ResolveIntegerValue(string flagKey, int defaultValue, EvaluationContext context = null)
+        public Task<ResolutionDetails<int>> ResolveIntegerValueAsync(string flagKey, int defaultValue, EvaluationContext context = null)
         {
-            return Task.FromResult(_evaluator.ResolveIntegerValue(flagKey, defaultValue, context));
+            return Task.FromResult(_evaluator.ResolveIntegerValueAsync(flagKey, defaultValue, context));
         }
 
-        public Task<ResolutionDetails<double>> ResolveDoubleValue(string flagKey, double defaultValue, EvaluationContext context = null)
+        public Task<ResolutionDetails<double>> ResolveDoubleValueAsync(string flagKey, double defaultValue, EvaluationContext context = null)
         {
-            return Task.FromResult(_evaluator.ResolveDoubleValue(flagKey, defaultValue, context));
+            return Task.FromResult(_evaluator.ResolveDoubleValueAsync(flagKey, defaultValue, context));
         }
 
-        public Task<ResolutionDetails<Value>> ResolveStructureValue(string flagKey, Value defaultValue, EvaluationContext context = null)
+        public Task<ResolutionDetails<Value>> ResolveStructureValueAsync(string flagKey, Value defaultValue, EvaluationContext context = null)
         {
-            return Task.FromResult(_evaluator.ResolveStructureValue(flagKey, defaultValue, context));
+            return Task.FromResult(_evaluator.ResolveStructureValueAsync(flagKey, defaultValue, context));
         }
 
         private async void HandleEvents(CountdownEvent latch)

--- a/src/OpenFeature.Contrib.Providers.Flagd/Resolver/InProcess/JsonEvaluator.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/Resolver/InProcess/JsonEvaluator.cs
@@ -122,27 +122,27 @@ namespace OpenFeature.Contrib.Providers.Flagd.Resolver.InProcess
             }
         }
 
-        public ResolutionDetails<bool> ResolveBooleanValue(string flagKey, bool defaultValue, EvaluationContext context = null)
+        public ResolutionDetails<bool> ResolveBooleanValueAsync(string flagKey, bool defaultValue, EvaluationContext context = null)
         {
             return ResolveValue(flagKey, defaultValue, context);
         }
 
-        public ResolutionDetails<string> ResolveStringValue(string flagKey, string defaultValue, EvaluationContext context = null)
+        public ResolutionDetails<string> ResolveStringValueAsync(string flagKey, string defaultValue, EvaluationContext context = null)
         {
             return ResolveValue(flagKey, defaultValue, context);
         }
 
-        public ResolutionDetails<int> ResolveIntegerValue(string flagKey, int defaultValue, EvaluationContext context = null)
+        public ResolutionDetails<int> ResolveIntegerValueAsync(string flagKey, int defaultValue, EvaluationContext context = null)
         {
             return ResolveValue(flagKey, defaultValue, context);
         }
 
-        public ResolutionDetails<double> ResolveDoubleValue(string flagKey, double defaultValue, EvaluationContext context = null)
+        public ResolutionDetails<double> ResolveDoubleValueAsync(string flagKey, double defaultValue, EvaluationContext context = null)
         {
             return ResolveValue(flagKey, defaultValue, context);
         }
 
-        public ResolutionDetails<Value> ResolveStructureValue(string flagKey, Value defaultValue, EvaluationContext context = null)
+        public ResolutionDetails<Value> ResolveStructureValueAsync(string flagKey, Value defaultValue, EvaluationContext context = null)
         {
             return ResolveValue(flagKey, defaultValue, context);
         }

--- a/src/OpenFeature.Contrib.Providers.Flagd/Resolver/Resolver.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/Resolver/Resolver.cs
@@ -9,19 +9,19 @@ namespace OpenFeature.Contrib.Providers.Flagd.Resolver
         Task Init();
         Task Shutdown();
 
-        Task<ResolutionDetails<bool>> ResolveBooleanValue(string flagKey, bool defaultValue,
+        Task<ResolutionDetails<bool>> ResolveBooleanValueAsync(string flagKey, bool defaultValue,
             EvaluationContext context = null);
 
-        Task<ResolutionDetails<string>> ResolveStringValue(string flagKey, string defaultValue,
+        Task<ResolutionDetails<string>> ResolveStringValueAsync(string flagKey, string defaultValue,
             EvaluationContext context = null);
 
-        Task<ResolutionDetails<int>> ResolveIntegerValue(string flagKey, int defaultValue,
+        Task<ResolutionDetails<int>> ResolveIntegerValueAsync(string flagKey, int defaultValue,
             EvaluationContext context = null);
 
-        Task<ResolutionDetails<double>> ResolveDoubleValue(string flagKey, double defaultValue,
+        Task<ResolutionDetails<double>> ResolveDoubleValueAsync(string flagKey, double defaultValue,
             EvaluationContext context = null);
 
-        Task<ResolutionDetails<Value>> ResolveStructureValue(string flagKey, Value defaultValue,
+        Task<ResolutionDetails<Value>> ResolveStructureValueAsync(string flagKey, Value defaultValue,
             EvaluationContext context = null);
     }
 }

--- a/src/OpenFeature.Contrib.Providers.Flagd/Resolver/Rpc/RpcResolver.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/Resolver/Rpc/RpcResolver.cs
@@ -73,7 +73,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Resolver.Rpc
             });
         }
 
-        public async Task<ResolutionDetails<bool>> ResolveBooleanValue(string flagKey, bool defaultValue, EvaluationContext context = null)
+        public async Task<ResolutionDetails<bool>> ResolveBooleanValueAsync(string flagKey, bool defaultValue, EvaluationContext context = null)
         {
             return await ResolveValue(flagKey, async contextStruct =>
             {
@@ -92,7 +92,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Resolver.Rpc
             }, context);
         }
 
-        public async Task<ResolutionDetails<string>> ResolveStringValue(string flagKey, string defaultValue, EvaluationContext context = null)
+        public async Task<ResolutionDetails<string>> ResolveStringValueAsync(string flagKey, string defaultValue, EvaluationContext context = null)
         {
             return await ResolveValue(flagKey, async contextStruct =>
             {
@@ -111,7 +111,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Resolver.Rpc
             }, context);
         }
 
-        public async Task<ResolutionDetails<int>> ResolveIntegerValue(string flagKey, int defaultValue, EvaluationContext context = null)
+        public async Task<ResolutionDetails<int>> ResolveIntegerValueAsync(string flagKey, int defaultValue, EvaluationContext context = null)
         {
             return await ResolveValue(flagKey, async contextStruct =>
             {
@@ -130,7 +130,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Resolver.Rpc
             }, context);
         }
 
-        public async Task<ResolutionDetails<double>> ResolveDoubleValue(string flagKey, double defaultValue, EvaluationContext context = null)
+        public async Task<ResolutionDetails<double>> ResolveDoubleValueAsync(string flagKey, double defaultValue, EvaluationContext context = null)
         {
             return await ResolveValue(flagKey, async contextStruct =>
             {
@@ -149,7 +149,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Resolver.Rpc
             }, context);
         }
 
-        public async Task<ResolutionDetails<Value>> ResolveStructureValue(string flagKey, Value defaultValue, EvaluationContext context = null)
+        public async Task<ResolutionDetails<Value>> ResolveStructureValueAsync(string flagKey, Value defaultValue, EvaluationContext context = null)
         {
             return await ResolveValue(flagKey, async contextStruct =>
             {

--- a/src/OpenFeature.Contrib.Providers.Flagsmith/FlagsmithProvider.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagsmith/FlagsmithProvider.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Trait = Flagsmith.Trait;
 using OpenFeature.Error;
 using System.Globalization;
+using System.Threading;
 
 namespace OpenFeature.Contrib.Providers.Flagsmith
 {
@@ -108,27 +109,27 @@ namespace OpenFeature.Contrib.Providers.Flagsmith
 
         /// <inheritdoc/>
 
-        public override Task<ResolutionDetails<bool>> ResolveBooleanValue(string flagKey, bool defaultValue, EvaluationContext context = null)
+        public override Task<ResolutionDetails<bool>> ResolveBooleanValueAsync(string flagKey, bool defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
             => Configuration.UsingBooleanConfigValue
             ? ResolveValue(flagKey, defaultValue, bool.TryParse, context)
             : IsFeatureEnabled(flagKey, context);
 
         /// <inheritdoc/>
-        public override Task<ResolutionDetails<int>> ResolveIntegerValue(string flagKey, int defaultValue, EvaluationContext context = null)
+        public override Task<ResolutionDetails<int>> ResolveIntegerValueAsync(string flagKey, int defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
             => ResolveValue(flagKey, defaultValue, int.TryParse, context);
 
         /// <inheritdoc/>
-        public override Task<ResolutionDetails<double>> ResolveDoubleValue(string flagKey, double defaultValue, EvaluationContext context = null)
+        public override Task<ResolutionDetails<double>> ResolveDoubleValueAsync(string flagKey, double defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
             => ResolveValue(flagKey, defaultValue, (string x, out double y) => double.TryParse(x, NumberStyles.Any, CultureInfo.InvariantCulture, out y), context);
 
 
         /// <inheritdoc/>
-        public override Task<ResolutionDetails<string>> ResolveStringValue(string flagKey, string defaultValue, EvaluationContext context = null)
+        public override Task<ResolutionDetails<string>> ResolveStringValueAsync(string flagKey, string defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
             => ResolveValue(flagKey, defaultValue, (string x, out string y) => { y = x; return true; }, context);
 
 
         /// <inheritdoc/>
-        public override Task<ResolutionDetails<Value>> ResolveStructureValue(string flagKey, Value defaultValue, EvaluationContext context = null)
+        public override Task<ResolutionDetails<Value>> ResolveStructureValueAsync(string flagKey, Value defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
             => ResolveValue(flagKey, defaultValue, TryParseValue, context);
 
         private bool TryParseValue(string stringValue, out Value result)

--- a/src/OpenFeature.Contrib.Providers.Flagsmith/README.md
+++ b/src/OpenFeature.Contrib.Providers.Flagsmith/README.md
@@ -79,7 +79,7 @@ var context = EvaluationContext.Builder()
     .Build();
 
 // Evaluate a flag
-var val = await client.GetBooleanValue("myBoolFlag", false, context);
+var val = await client.GetBooleanValueAsync("myBoolFlag", false, context);
 
 // Print the value of the 'myBoolFlag' feature flag
 Console.WriteLine(val);

--- a/src/OpenFeature.Contrib.Providers.GOFeatureFlag/GoFeatureFlagProvider.cs
+++ b/src/OpenFeature.Contrib.Providers.GOFeatureFlag/GoFeatureFlagProvider.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using OpenFeature.Constant;
 using OpenFeature.Contrib.Providers.GOFeatureFlag.exception;
@@ -78,18 +79,19 @@ namespace OpenFeature.Contrib.Providers.GOFeatureFlag
         }
 
         /// <summary>
-        ///     ResolveBooleanValue resolve the value for a Boolean Flag.
+        ///     ResolveBooleanValueAsync resolve the value for a Boolean Flag.
         /// </summary>
         /// <param name="flagKey">Name of the flag</param>
         /// <param name="defaultValue">Default value used in case of error.</param>
         /// <param name="context">Context about the user</param>
+        /// <param name="cancellationToken">Token for cancel the async operation</param>
         /// <returns>A ResolutionDetails object containing the value of your flag</returns>
         /// <exception cref="TypeMismatchError">If the type of the flag does not match</exception>
         /// <exception cref="FlagNotFoundError">If the flag does not exists</exception>
         /// <exception cref="GeneralError">If an unknown error happen</exception>
         /// <exception cref="FlagDisabled">If the flag is disabled</exception>
-        public override async Task<ResolutionDetails<bool>> ResolveBooleanValue(string flagKey, bool defaultValue,
-            EvaluationContext context = null)
+        public override async Task<ResolutionDetails<bool>> ResolveBooleanValueAsync(string flagKey, bool defaultValue,
+            EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
             try
             {
@@ -108,18 +110,19 @@ namespace OpenFeature.Contrib.Providers.GOFeatureFlag
         }
 
         /// <summary>
-        ///     ResolveBooleanValue resolve the value for a string Flag.
+        ///     ResolveBooleanValueAsync resolve the value for a string Flag.
         /// </summary>
         /// <param name="flagKey">Name of the flag</param>
         /// <param name="defaultValue">Default value used in case of error.</param>
         /// <param name="context">Context about the user</param>
+        /// <param name="cancellationToken">Token for cancel the async operation</param>
         /// <returns>A ResolutionDetails object containing the value of your flag</returns>
         /// <exception cref="TypeMismatchError">If the type of the flag does not match</exception>
         /// <exception cref="FlagNotFoundError">If the flag does not exists</exception>
         /// <exception cref="GeneralError">If an unknown error happen</exception>
         /// <exception cref="FlagDisabled">If the flag is disabled</exception>
-        public override async Task<ResolutionDetails<string>> ResolveStringValue(string flagKey, string defaultValue,
-            EvaluationContext context = null)
+        public override async Task<ResolutionDetails<string>> ResolveStringValueAsync(string flagKey, string defaultValue,
+            EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
             try
             {
@@ -140,18 +143,19 @@ namespace OpenFeature.Contrib.Providers.GOFeatureFlag
         }
 
         /// <summary>
-        ///     ResolveBooleanValue resolve the value for an int Flag.
+        ///     ResolveBooleanValueAsync resolve the value for an int Flag.
         /// </summary>
         /// <param name="flagKey">Name of the flag</param>
         /// <param name="defaultValue">Default value used in case of error.</param>
         /// <param name="context">Context about the user</param>
+        /// <param name="cancellationToken">Token for cancel the async operation</param>
         /// <returns>A ResolutionDetails object containing the value of your flag</returns>
         /// <exception cref="TypeMismatchError">If the type of the flag does not match</exception>
         /// <exception cref="FlagNotFoundError">If the flag does not exists</exception>
         /// <exception cref="GeneralError">If an unknown error happen</exception>
         /// <exception cref="FlagDisabled">If the flag is disabled</exception>
-        public override async Task<ResolutionDetails<int>> ResolveIntegerValue(string flagKey, int defaultValue,
-            EvaluationContext context = null)
+        public override async Task<ResolutionDetails<int>> ResolveIntegerValueAsync(string flagKey, int defaultValue,
+            EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
             try
             {
@@ -170,18 +174,19 @@ namespace OpenFeature.Contrib.Providers.GOFeatureFlag
         }
 
         /// <summary>
-        ///     ResolveBooleanValue resolve the value for a double Flag.
+        ///     ResolveBooleanValueAsync resolve the value for a double Flag.
         /// </summary>
         /// <param name="flagKey">Name of the flag</param>
         /// <param name="defaultValue">Default value used in case of error.</param>
         /// <param name="context">Context about the user</param>
+        /// <param name="cancellationToken">Token for cancel the async operation</param>
         /// <returns>A ResolutionDetails object containing the value of your flag</returns>
         /// <exception cref="TypeMismatchError">If the type of the flag does not match</exception>
         /// <exception cref="FlagNotFoundError">If the flag does not exists</exception>
         /// <exception cref="GeneralError">If an unknown error happen</exception>
         /// <exception cref="FlagDisabled">If the flag is disabled</exception>
-        public override async Task<ResolutionDetails<double>> ResolveDoubleValue(string flagKey, double defaultValue,
-            EvaluationContext context = null)
+        public override async Task<ResolutionDetails<double>> ResolveDoubleValueAsync(string flagKey, double defaultValue,
+            EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
             try
             {
@@ -201,18 +206,19 @@ namespace OpenFeature.Contrib.Providers.GOFeatureFlag
         }
 
         /// <summary>
-        ///     ResolveBooleanValue resolve the value for a Boolean Flag.
+        ///     ResolveBooleanValueAsync resolve the value for a Boolean Flag.
         /// </summary>
         /// <param name="flagKey">Name of the flag</param>
         /// <param name="defaultValue">Default value used in case of error.</param>
         /// <param name="context">Context about the user</param>
+        /// <param name="cancellationToken">Token for cancel the async operation</param>
         /// <returns>A ResolutionDetails object containing the value of your flag</returns>
         /// <exception cref="TypeMismatchError">If the type of the flag does not match</exception>
         /// <exception cref="FlagNotFoundError">If the flag does not exists</exception>
         /// <exception cref="GeneralError">If an unknown error happen</exception>
         /// <exception cref="FlagDisabled">If the flag is disabled</exception>
-        public override async Task<ResolutionDetails<Value>> ResolveStructureValue(string flagKey, Value defaultValue,
-            EvaluationContext context = null)
+        public override async Task<ResolutionDetails<Value>> ResolveStructureValueAsync(string flagKey, Value defaultValue,
+            EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
             try
             {

--- a/src/OpenFeature.Contrib.Providers.GOFeatureFlag/OpenFeature.Contrib.Providers.GOFeatureFlag.csproj
+++ b/src/OpenFeature.Contrib.Providers.GOFeatureFlag/OpenFeature.Contrib.Providers.GOFeatureFlag.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0'">
 	<PackageReference Include="System.Text.Json" Version="8.0.4" />
+  <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/OpenFeature.Contrib.Providers.GOFeatureFlag/README.md
+++ b/src/OpenFeature.Contrib.Providers.GOFeatureFlag/README.md
@@ -88,7 +88,7 @@ var userContext = EvaluationContext.Builder()
     .Set("anonymous", false)
     .Build();
 
-var adminFlag = await client.GetBooleanValue("flag-only-for-admin", false, userContext);
+var adminFlag = await client.GetBooleanValueAsync("flag-only-for-admin", false, userContext);
 if (adminFlag) {
    // flag "flag-only-for-admin" is true for the user
 } else {

--- a/src/OpenFeature.Contrib.Providers.Statsig/README.md
+++ b/src/OpenFeature.Contrib.Providers.Statsig/README.md
@@ -1,6 +1,6 @@
 # Statsig Feature Flag .NET Provider
 
-The Statsig Flag provider allows you to connect to Statsig. Please note this is a minimal implementation - only `ResolveBooleanValue` is implemented.
+The Statsig Flag provider allows you to connect to Statsig. Please note this is a minimal implementation - only `ResolveBooleanValueAsync` is implemented.
 
 # .Net SDK usage
 
@@ -61,7 +61,7 @@ eb.SetTargetingKey("john@doe.acme");
 
 IFeatureClient client = Api.Instance.GetClient(context: eb.Build());
 
-bool isMyAwesomeFeatureEnabled = await client.GetBooleanValue("isMyAwesomeFeatureEnabled", false);
+bool isMyAwesomeFeatureEnabled = await client.GetBooleanValueAsync("isMyAwesomeFeatureEnabled", false);
 
 if (isMyAwesomeFeatureEnabled)
 {
@@ -97,4 +97,4 @@ The following parameters are mapped to the corresponding Statsig pre-defined par
 | `privateAttributes`   | `PrivateAttributes`       |
 
 ## Known issues and limitations
-- Only `ResolveBooleanValue` implemented for now
+- Only `ResolveBooleanValueAsync` implemented for now

--- a/test/OpenFeature.Contrib.Hooks.Otel.Test/MetricsHookTest.cs
+++ b/test/OpenFeature.Contrib.Hooks.Otel.Test/MetricsHookTest.cs
@@ -33,7 +33,7 @@ namespace OpenFeature.Contrib.Hooks.Otel.Test
             var otelHook = new MetricsHook();
 
             // Act
-            await otelHook.After(hookContext, new FlagEvaluationDetails<string>("my-flag", "foo", Constant.ErrorType.None, "STATIC", "default"), new Dictionary<string, object>());
+            await otelHook.AfterAsync(hookContext, new FlagEvaluationDetails<string>("my-flag", "foo", Constant.ErrorType.None, "STATIC", "default"), new Dictionary<string, object>());
 
             // Flush metrics
             meterProvider.ForceFlush();
@@ -57,7 +57,7 @@ namespace OpenFeature.Contrib.Hooks.Otel.Test
             var otelHook = new MetricsHook();
 
             // Act
-            await otelHook.Error(hookContext, new Exception(), new Dictionary<string, object>());
+            await otelHook.ErrorAsync(hookContext, new Exception(), new Dictionary<string, object>());
 
             // Flush metrics
             meterProvider.ForceFlush();
@@ -81,7 +81,7 @@ namespace OpenFeature.Contrib.Hooks.Otel.Test
             var otelHook = new MetricsHook();
 
             // Act
-            await otelHook.Finally(hookContext, new Dictionary<string, object>());
+            await otelHook.FinallyAsync(hookContext, new Dictionary<string, object>());
 
             // Flush metrics
             meterProvider.ForceFlush();
@@ -107,7 +107,7 @@ namespace OpenFeature.Contrib.Hooks.Otel.Test
             var otelHook = new MetricsHook();
 
             // Act
-            await otelHook.Before(hookContext, new Dictionary<string, object>());
+            await otelHook.BeforeAsync(hookContext, new Dictionary<string, object>());
 
             // Flush metrics
             meterProvider.ForceFlush();

--- a/test/OpenFeature.Contrib.Hooks.Otel.Test/TracingHookTest.cs
+++ b/test/OpenFeature.Contrib.Hooks.Otel.Test/TracingHookTest.cs
@@ -38,7 +38,7 @@ namespace OpenFeature.Contrib.Hooks.Otel.Test
 
             var ctx = new HookContext<string>("my-flag", "foo", Constant.FlagValueType.String, new ClientMetadata("my-client", "1.0"), new Metadata("my-provider"), evaluationContext);
 
-            var hookTask = otelHook.After<string>(ctx, new FlagEvaluationDetails<string>("my-flag", "foo", Constant.ErrorType.None, "STATIC", "default"), new Dictionary<string, object>());
+            var hookTask = otelHook.AfterAsync<string>(ctx, new FlagEvaluationDetails<string>("my-flag", "foo", Constant.ErrorType.None, "STATIC", "default"), new Dictionary<string, object>());
 
             Assert.True(hookTask.IsCompleted);
 
@@ -99,7 +99,7 @@ namespace OpenFeature.Contrib.Hooks.Otel.Test
 
             var ctx = new HookContext<string>("my-flag", "foo", Constant.FlagValueType.String, new ClientMetadata("my-client", "1.0"), new Metadata("my-provider"), evaluationContext);
 
-            var hookTask = otelHook.After<string>(ctx, new FlagEvaluationDetails<string>("my-flag", "foo", Constant.ErrorType.None, "STATIC", "default"), new Dictionary<string, object>());
+            var hookTask = otelHook.AfterAsync<string>(ctx, new FlagEvaluationDetails<string>("my-flag", "foo", Constant.ErrorType.None, "STATIC", "default"), new Dictionary<string, object>());
 
             Assert.True(hookTask.IsCompleted);
 
@@ -132,7 +132,7 @@ namespace OpenFeature.Contrib.Hooks.Otel.Test
 
             var ctx = new HookContext<string>("my-flag", "foo", Constant.FlagValueType.String, new ClientMetadata("my-client", "1.0"), new Metadata("my-provider"), evaluationContext);
 
-            var hookTask = otelHook.Error<string>(ctx, new System.Exception("unexpected error"), new Dictionary<string, object>());
+            var hookTask = otelHook.ErrorAsync<string>(ctx, new System.Exception("unexpected error"), new Dictionary<string, object>());
 
             Assert.True(hookTask.IsCompleted);
 
@@ -181,7 +181,7 @@ namespace OpenFeature.Contrib.Hooks.Otel.Test
 
             var ctx = new HookContext<string>("my-flag", "foo", Constant.FlagValueType.String, new ClientMetadata("my-client", "1.0"), new Metadata("my-provider"), evaluationContext);
 
-            var hookTask = otelHook.Error<string>(ctx, new System.Exception("unexpected error"), new Dictionary<string, object>());
+            var hookTask = otelHook.ErrorAsync<string>(ctx, new System.Exception("unexpected error"), new Dictionary<string, object>());
 
             Assert.True(hookTask.IsCompleted);
 

--- a/test/OpenFeature.Contrib.Providers.ConfigCat.Test/ConfigCatProviderTest.cs
+++ b/test/OpenFeature.Contrib.Providers.ConfigCat.Test/ConfigCatProviderTest.cs
@@ -25,54 +25,54 @@ namespace OpenFeature.Contrib.ConfigCat.Test
         [Theory]
         [InlineAutoData(true, false, true)]
         [InlineAutoData(false, true, false)]
-        public Task GetBooleanValue_ForFeature_ReturnExpectedResult(object value, bool defaultValue, bool expectedValue, string sdkKey)
+        public Task GetBooleanValueAsync_ForFeature_ReturnExpectedResult(object value, bool defaultValue, bool expectedValue, string sdkKey)
         {
-            return ExecuteResolveTest(value, defaultValue, expectedValue, sdkKey, (provider, key, def) => provider.ResolveBooleanValue(key, def));
+            return ExecuteResolveTest(value, defaultValue, expectedValue, sdkKey, (provider, key, def) => provider.ResolveBooleanValueAsync(key, def));
         }
 
         [Theory]
         [InlineAutoData("false", true, ErrorType.TypeMismatch)]
-        public Task GetBooleanValue_ForFeature_ShouldThrowException(object value, bool defaultValue, ErrorType expectedErrorType, string sdkKey)
+        public Task GetBooleanValueAsync_ForFeature_ShouldThrowException(object value, bool defaultValue, ErrorType expectedErrorType, string sdkKey)
         {
-            return ExecuteResolveErrorTest(value, defaultValue, expectedErrorType, sdkKey, (provider, key, def) => provider.ResolveBooleanValue(key, def));
+            return ExecuteResolveErrorTest(value, defaultValue, expectedErrorType, sdkKey, (provider, key, def) => provider.ResolveBooleanValueAsync(key, def));
         }
 
         [Theory]
         [InlineAutoData(1.0, 2.0, 1.0)]
-        public Task GetDoubleValue_ForFeature_ReturnExpectedResult(object value, double defaultValue, double expectedValue, string sdkKey)
+        public Task GetDoubleValueAsync_ForFeature_ReturnExpectedResult(object value, double defaultValue, double expectedValue, string sdkKey)
         {
-            return ExecuteResolveTest(value, defaultValue, expectedValue, sdkKey, (provider, key, def) => provider.ResolveDoubleValue(key, def));
+            return ExecuteResolveTest(value, defaultValue, expectedValue, sdkKey, (provider, key, def) => provider.ResolveDoubleValueAsync(key, def));
         }
 
         [Theory]
         [InlineAutoData(1, 0, ErrorType.TypeMismatch)]
         [InlineAutoData("false", 0, ErrorType.TypeMismatch)]
         [InlineAutoData(false, 0, ErrorType.TypeMismatch)]
-        public Task GetDoubleValue_ForFeature_ShouldThrowException(object value, double defaultValue, ErrorType expectedErrorType, string sdkKey)
+        public Task GetDoubleValueAsync_ForFeature_ShouldThrowException(object value, double defaultValue, ErrorType expectedErrorType, string sdkKey)
         {
-            return ExecuteResolveErrorTest(value, defaultValue, expectedErrorType, sdkKey, (provider, key, def) => provider.ResolveDoubleValue(key, def));
+            return ExecuteResolveErrorTest(value, defaultValue, expectedErrorType, sdkKey, (provider, key, def) => provider.ResolveDoubleValueAsync(key, def));
         }
 
         [Theory]
         [InlineAutoData("some-value", "empty", "some-value")]
-        public Task GetStringValue_ForFeature_ReturnExpectedResult(object value, string defaultValue, string expectedValue, string sdkKey)
+        public Task GetStringValueAsync_ForFeature_ReturnExpectedResult(object value, string defaultValue, string expectedValue, string sdkKey)
         {
-            return ExecuteResolveTest(value, defaultValue, expectedValue, sdkKey, (provider, key, def) => provider.ResolveStringValue(key, def));
+            return ExecuteResolveTest(value, defaultValue, expectedValue, sdkKey, (provider, key, def) => provider.ResolveStringValueAsync(key, def));
         }
 
         [Theory]
         [InlineAutoData(1, "empty", ErrorType.TypeMismatch)]
         [InlineAutoData(false, "empty", ErrorType.TypeMismatch)]
-        public Task GetStringValue_ForFeature_ShouldThrowException(object value, string defaultValue, ErrorType expectedErrorType, string sdkKey)
+        public Task GetStringValueAsync_ForFeature_ShouldThrowException(object value, string defaultValue, ErrorType expectedErrorType, string sdkKey)
         {
-            return ExecuteResolveErrorTest(value, defaultValue, expectedErrorType, sdkKey, (provider, key, def) => provider.ResolveStringValue(key, def));
+            return ExecuteResolveErrorTest(value, defaultValue, expectedErrorType, sdkKey, (provider, key, def) => provider.ResolveStringValueAsync(key, def));
         }
 
         [Theory]
         [InlineAutoData(1, 2, 1)]
         public Task GetIntValue_ForFeature_ReturnExpectedResult(object value, int defaultValue, int expectedValue, string sdkKey)
         {
-            return ExecuteResolveTest(value, defaultValue, expectedValue, sdkKey, (provider, key, def) => provider.ResolveIntegerValue(key, def));
+            return ExecuteResolveTest(value, defaultValue, expectedValue, sdkKey, (provider, key, def) => provider.ResolveIntegerValueAsync(key, def));
         }
 
         [Theory]
@@ -81,19 +81,19 @@ namespace OpenFeature.Contrib.ConfigCat.Test
         [InlineAutoData(false, 0, ErrorType.TypeMismatch)]
         public Task GetIntValue_ForFeature_ShouldThrowException(object value, int defaultValue, ErrorType expectedErrorType, string sdkKey)
         {
-            return ExecuteResolveErrorTest(value, defaultValue, expectedErrorType, sdkKey, (provider, key, def) => provider.ResolveIntegerValue(key, def));
+            return ExecuteResolveErrorTest(value, defaultValue, expectedErrorType, sdkKey, (provider, key, def) => provider.ResolveIntegerValueAsync(key, def));
         }
 
         [Theory]
         [AutoData]
-        public async Task GetStructureValue_ForFeature_ReturnExpectedResult(string sdkKey)
+        public async Task GetStructureValueAsync_ForFeature_ReturnExpectedResult(string sdkKey)
         {
             const string jsonValue = "{ \"key\": \"value\" }";
             var defaultValue = new Value(jsonValue);
             var configCatProvider = new ConfigCatProvider(sdkKey,
                 options => { options.FlagOverrides = BuildFlagOverrides(("example-feature", defaultValue.AsString)); });
 
-            var result = await configCatProvider.ResolveStructureValue("example-feature", defaultValue);
+            var result = await configCatProvider.ResolveStructureValueAsync("example-feature", defaultValue);
 
             Assert.Equal(defaultValue.AsString, result.Value.AsString);
             Assert.Equal("example-feature", result.FlagKey);

--- a/test/OpenFeature.Contrib.Providers.FeatureManagement.Test/FeatureManagementProviderTestNoContext.cs
+++ b/test/OpenFeature.Contrib.Providers.FeatureManagement.Test/FeatureManagementProviderTestNoContext.cs
@@ -19,7 +19,7 @@ namespace OpenFeature.Contrib.Providers.FeatureManagement.Test
 
             // Act
             // Invert the expected value to ensure that the value is being read from the configuration
-            var result = await provider.ResolveBooleanValue(key, defaultValue);
+            var result = await provider.ResolveBooleanValueAsync(key, defaultValue);
 
             // Assert
             Assert.Equal(expectedValue, result.Value);
@@ -37,7 +37,7 @@ namespace OpenFeature.Contrib.Providers.FeatureManagement.Test
 
             // Act
             // Using 0.0 for the default to verify the value is being read from the configuration
-            var result = await provider.ResolveDoubleValue(key, defaultValue);
+            var result = await provider.ResolveDoubleValueAsync(key, defaultValue);
 
             // Assert
             Assert.Equal(expectedValue, result.Value);
@@ -55,7 +55,7 @@ namespace OpenFeature.Contrib.Providers.FeatureManagement.Test
 
             // Act
             // Using 0 for the default to verify the value is being read from the configuration
-            var result = await provider.ResolveIntegerValue(key, defaultValue);
+            var result = await provider.ResolveIntegerValueAsync(key, defaultValue);
 
             // Assert
             Assert.Equal(expectedValue, result.Value);
@@ -73,7 +73,7 @@ namespace OpenFeature.Contrib.Providers.FeatureManagement.Test
 
             // Act
             // Using 0 for the default to verify the value is being read from the configuration
-            var result = await provider.ResolveStringValue(key, defaultValue);
+            var result = await provider.ResolveStringValueAsync(key, defaultValue);
 
             // Assert
             Assert.Equal(expectedValue, result.Value);
@@ -91,7 +91,7 @@ namespace OpenFeature.Contrib.Providers.FeatureManagement.Test
 
             // Act
             // Using 0 for the default to verify the value is being read from the configuration
-            var result = await provider.ResolveStructureValue(key, null);
+            var result = await provider.ResolveStructureValueAsync(key, null);
 
             // Assert
             Assert.NotNull(result);

--- a/test/OpenFeature.Contrib.Providers.FeatureManagement.Test/FeatureManagementProviderTestWithContext.cs
+++ b/test/OpenFeature.Contrib.Providers.FeatureManagement.Test/FeatureManagementProviderTestWithContext.cs
@@ -38,7 +38,7 @@ namespace OpenFeature.Contrib.Providers.FeatureManagement.Test
             var provider = new FeatureManagementProvider(configuration);
 
             // Act
-            var result = await provider.ResolveBooleanValue("MissingFlagKey", defaultValue, evaluationContext);
+            var result = await provider.ResolveBooleanValueAsync("MissingFlagKey", defaultValue, evaluationContext);
 
             // Assert
             Assert.Equal(defaultValue, result.Value);
@@ -57,7 +57,7 @@ namespace OpenFeature.Contrib.Providers.FeatureManagement.Test
             var provider = new FeatureManagementProvider(configuration);
 
             // Act
-            var result = await provider.ResolveBooleanValue(key, defaultValue, evaluationContext);
+            var result = await provider.ResolveBooleanValueAsync(key, defaultValue, evaluationContext);
 
             // Assert
             Assert.Equal(expectedValue, result.Value);
@@ -76,7 +76,7 @@ namespace OpenFeature.Contrib.Providers.FeatureManagement.Test
 
             // Act
             // Using 0.0 for the default to verify the value is being read from the configuration
-            var result = await provider.ResolveDoubleValue(key, defaultValue, evaluationContext);
+            var result = await provider.ResolveDoubleValueAsync(key, defaultValue, evaluationContext);
 
             // Assert
             Assert.Equal(expectedValue, result.Value);
@@ -95,7 +95,7 @@ namespace OpenFeature.Contrib.Providers.FeatureManagement.Test
 
             // Act
             // Using 0 for the default to verify the value is being read from the configuration
-            var result = await provider.ResolveIntegerValue(key, defaultValue, evaluationContext);
+            var result = await provider.ResolveIntegerValueAsync(key, defaultValue, evaluationContext);
 
             // Assert
             Assert.Equal(expectedValue, result.Value);
@@ -114,7 +114,7 @@ namespace OpenFeature.Contrib.Providers.FeatureManagement.Test
 
             // Act
             // Using 0 for the default to verify the value is being read from the configuration
-            var result = await provider.ResolveStringValue(key, defaultValue, evaluationContext);
+            var result = await provider.ResolveStringValueAsync(key, defaultValue, evaluationContext);
 
             // Assert
             Assert.Equal(expectedValue, result.Value);
@@ -132,7 +132,7 @@ namespace OpenFeature.Contrib.Providers.FeatureManagement.Test
             var provider = new FeatureManagementProvider(configuration);
 
             // Act
-            var result = await provider.ResolveStructureValue(key, null, evaluationContext);
+            var result = await provider.ResolveStructureValueAsync(key, null, evaluationContext);
 
             // Assert
             Assert.NotNull(result);
@@ -153,7 +153,7 @@ namespace OpenFeature.Contrib.Providers.FeatureManagement.Test
             var provider = new FeatureManagementProvider(configuration);
 
             // Act
-            var result = await provider.ResolveStructureValue(key, null, evaluationContext);
+            var result = await provider.ResolveStructureValueAsync(key, null, evaluationContext);
 
             // Assert
             Assert.NotNull(result);

--- a/test/OpenFeature.Contrib.Providers.Flagd.E2e.Test/Steps/EvaluationStepDefinitionBase.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagd.E2e.Test/Steps/EvaluationStepDefinitionBase.cs
@@ -51,7 +51,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.E2e.Test
         [When(@"a boolean flag with key ""(.*)"" is evaluated with default value ""(.*)""")]
         public void Whenabooleanflagwithkeyisevaluatedwithdefaultvalue(string flagKey, bool defaultValue)
         {
-            this.booleanFlagValue = client.GetBooleanValue(flagKey, defaultValue);
+            this.booleanFlagValue = client.GetBooleanValueAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved boolean value should be ""(.*)""")]
@@ -63,7 +63,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.E2e.Test
         [When(@"a string flag with key ""(.*)"" is evaluated with default value ""(.*)""")]
         public void Whenastringflagwithkeyisevaluatedwithdefaultvalue(string flagKey, string defaultValue)
         {
-            this.stringFlagValue = client.GetStringValue(flagKey, defaultValue);
+            this.stringFlagValue = client.GetStringValueAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved string value should be ""(.*)""")]
@@ -75,7 +75,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.E2e.Test
         [When(@"an integer flag with key ""(.*)"" is evaluated with default value (.*)")]
         public void Whenanintegerflagwithkeyisevaluatedwithdefaultvalue(string flagKey, int defaultValue)
         {
-            this.intFlagValue = client.GetIntegerValue(flagKey, defaultValue);
+            this.intFlagValue = client.GetIntegerValueAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved integer value should be (.*)")]
@@ -87,7 +87,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.E2e.Test
         [When(@"a float flag with key ""(.*)"" is evaluated with default value (.*)")]
         public void Whenafloatflagwithkeyisevaluatedwithdefaultvalue(string flagKey, double defaultValue)
         {
-            this.doubleFlagValue = client.GetDoubleValue(flagKey, defaultValue);
+            this.doubleFlagValue = client.GetDoubleValueAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved float value should be (.*)")]
@@ -99,7 +99,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.E2e.Test
         [When(@"an object flag with key ""(.*)"" is evaluated with a null default value")]
         public void Whenanobjectflagwithkeyisevaluatedwithanulldefaultvalue(string flagKey)
         {
-            this.objectFlagValue = client.GetObjectValue(flagKey, new Value());
+            this.objectFlagValue = client.GetObjectValueAsync(flagKey, new Value());
         }
 
         [Then(@"the resolved object value should be contain fields ""(.*)"", ""(.*)"", and ""(.*)"", with values ""(.*)"", ""(.*)"" and (.*), respectively")]
@@ -114,7 +114,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.E2e.Test
         [When(@"a boolean flag with key ""(.*)"" is evaluated with details and default value ""(.*)""")]
         public void Whenabooleanflagwithkeyisevaluatedwithdetailsanddefaultvalue(string flagKey, bool defaultValue)
         {
-            this.booleanFlagDetails = client.GetBooleanDetails(flagKey, defaultValue);
+            this.booleanFlagDetails = client.GetBooleanDetailsAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved boolean details value should be ""(.*)"", the variant should be ""(.*)"", and the reason should be ""(.*)""")]
@@ -129,7 +129,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.E2e.Test
         [When(@"a string flag with key ""(.*)"" is evaluated with details and default value ""(.*)""")]
         public void Whenastringflagwithkeyisevaluatedwithdetailsanddefaultvalue(string flagKey, string defaultValue)
         {
-            this.stringFlagDetails = client.GetStringDetails(flagKey, defaultValue);
+            this.stringFlagDetails = client.GetStringDetailsAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved string details value should be ""(.*)"", the variant should be ""(.*)"", and the reason should be ""(.*)""")]
@@ -144,7 +144,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.E2e.Test
         [When(@"an integer flag with key ""(.*)"" is evaluated with details and default value (.*)")]
         public void Whenanintegerflagwithkeyisevaluatedwithdetailsanddefaultvalue(string flagKey, int defaultValue)
         {
-            this.intFlagDetails = client.GetIntegerDetails(flagKey, defaultValue);
+            this.intFlagDetails = client.GetIntegerDetailsAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved integer details value should be (.*), the variant should be ""(.*)"", and the reason should be ""(.*)""")]
@@ -159,7 +159,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.E2e.Test
         [When(@"a float flag with key ""(.*)"" is evaluated with details and default value (.*)")]
         public void Whenafloatflagwithkeyisevaluatedwithdetailsanddefaultvalue(string flagKey, double defaultValue)
         {
-            this.doubleFlagDetails = client.GetDoubleDetails(flagKey, defaultValue);
+            this.doubleFlagDetails = client.GetDoubleDetailsAsync(flagKey, defaultValue);
         }
 
         [Then(@"the resolved float details value should be (.*), the variant should be ""(.*)"", and the reason should be ""(.*)""")]
@@ -174,7 +174,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.E2e.Test
         [When(@"an object flag with key ""(.*)"" is evaluated with details and a null default value")]
         public void Whenanobjectflagwithkeyisevaluatedwithdetailsandanulldefaultvalue(string flagKey)
         {
-            this.objectFlagDetails = client.GetObjectDetails(flagKey, new Value());
+            this.objectFlagDetails = client.GetObjectDetailsAsync(flagKey, new Value());
         }
 
         [Then(@"the resolved object details value should be contain fields ""(.*)"", ""(.*)"", and ""(.*)"", with values ""(.*)"", ""(.*)"" and (.*), respectively")]
@@ -210,7 +210,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.E2e.Test
         {
             contextAwareFlagKey = flagKey;
             contextAwareDefaultValue = defaultValue;
-            contextAwareValue = client.GetStringValue(flagKey, contextAwareDefaultValue, context).Result;
+            contextAwareValue = client.GetStringValueAsync(flagKey, contextAwareDefaultValue, context).Result;
         }
 
         [Then(@"the resolved string response should be ""(.*)""")]
@@ -222,7 +222,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.E2e.Test
         [Then(@"the resolved flag value is ""(.*)"" when the context is empty")]
         public void Giventheresolvedflagvalueiswhenthecontextisempty(string expected)
         {
-            string emptyContextValue = client.GetStringValue(contextAwareFlagKey, contextAwareDefaultValue, EvaluationContext.Empty).Result;
+            string emptyContextValue = client.GetStringValueAsync(contextAwareFlagKey, contextAwareDefaultValue, EvaluationContext.Empty).Result;
             Assert.Equal(expected, emptyContextValue);
         }
 
@@ -231,7 +231,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.E2e.Test
         {
             this.notFoundFlagKey = flagKey;
             this.notFoundDefaultValue = defaultValue;
-            this.notFoundDetails = client.GetStringDetails(this.notFoundFlagKey, this.notFoundDefaultValue).Result;
+            this.notFoundDetails = client.GetStringDetailsAsync(this.notFoundFlagKey, this.notFoundDefaultValue).Result;
         }
 
         [Then(@"the default string value should be returned")]
@@ -252,7 +252,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.E2e.Test
         {
             this.typeErrorFlagKey = flagKey;
             this.typeErrorDefaultValue = defaultValue;
-            this.typeErrorDetails = client.GetIntegerDetails(this.typeErrorFlagKey, this.typeErrorDefaultValue).Result;
+            this.typeErrorDetails = client.GetIntegerDetailsAsync(this.typeErrorFlagKey, this.typeErrorDefaultValue).Result;
         }
 
         [Then(@"the default integer value should be returned")]

--- a/test/OpenFeature.Contrib.Providers.Flagd.E2e.Test/Steps/FlagdStepDefinitionBase.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagd.E2e.Test/Steps/FlagdStepDefinitionBase.cs
@@ -90,7 +90,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.E2e.Test
         [When(@"a zero-value boolean flag with key ""(.*)"" is evaluated with default value ""(.*)""")]
         public void WhenAZero_ValueBooleanFlagWithKeyIsEvaluatedWithDefaultValue(string flagKey, string defaultValueString)
         {
-            booleanZeroValue = client.GetBooleanValue(flagKey, bool.Parse(defaultValueString));
+            booleanZeroValue = client.GetBooleanValueAsync(flagKey, bool.Parse(defaultValueString));
         }
 
         [Then(@"the resolved boolean zero-value should be ""(.*)""")]
@@ -102,7 +102,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.E2e.Test
         [When(@"a zero-value string flag with key ""(.*)"" is evaluated with default value ""(.*)""")]
         public void WhenAZero_ValueStringFlagWithKeyIsEvaluatedWithDefaultValue(string flagKey, string defaultValueString)
         {
-            stringZeroValue = client.GetStringValue(flagKey, defaultValueString);
+            stringZeroValue = client.GetStringValueAsync(flagKey, defaultValueString);
         }
 
         [Then(@"the resolved string zero-value should be ""(.*)""")]
@@ -114,7 +114,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.E2e.Test
         [When(@"a zero-value integer flag with key ""(.*)"" is evaluated with default value (.*)")]
         public void WhenAZero_ValueIntegerFlagWithKeyIsEvaluatedWithDefaultValue(string flagKey, string defaultValueString)
         {
-            intZeroFlagValue = client.GetIntegerValue(flagKey, int.Parse(defaultValueString));
+            intZeroFlagValue = client.GetIntegerValueAsync(flagKey, int.Parse(defaultValueString));
         }
 
         [Then(@"the resolved integer zero-value should be (.*)")]
@@ -126,7 +126,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.E2e.Test
         [When(@"a zero-value float flag with key ""(.*)"" is evaluated with default value (.*)")]
         public void WhenAZero_ValueFloatFlagWithKeyIsEvaluatedWithDefaultValue(string flagKey, decimal defaultValue)
         {
-            doubleZeroFlagValue = client.GetDoubleValue(flagKey, decimal.ToDouble(defaultValue));
+            doubleZeroFlagValue = client.GetDoubleValueAsync(flagKey, decimal.ToDouble(defaultValue));
         }
 
         [Then(@"the resolved float zero-value should be (.*)")]
@@ -185,21 +185,21 @@ namespace OpenFeature.Contrib.Providers.Flagd.E2e.Test
         [Then(@"the returned value should be ""(.*)""")]
         public async void ThenTheReturnedValueShouldBe(string expectedValue)
         {
-            var details = await client.GetStringDetails(stringFlagKey, stringDefaultValue, evaluationContext);
+            var details = await client.GetStringDetailsAsync(stringFlagKey, stringDefaultValue, evaluationContext);
             Assert.Equal(expectedValue, details.Value);
         }
 
         [Then(@"the returned value should be (.*)")]
         public async Task ThenTheReturnedValueShouldBeAsync(long expectedValue)
         {
-            var details = await client.GetIntegerDetails(intFlagKey, intDefaultValue, evaluationContext);
+            var details = await client.GetIntegerDetailsAsync(intFlagKey, intDefaultValue, evaluationContext);
             Assert.Equal(expectedValue, details.Value);
         }
 
         [Then(@"the returned reason should be ""(.*)""")]
         public async Task ThenTheReturnedReasonShouldBeAsync(string expectedReason)
         {
-            var details = await client.GetStringDetails(stringFlagKey, stringDefaultValue, evaluationContext);
+            var details = await client.GetStringDetailsAsync(stringFlagKey, stringDefaultValue, evaluationContext);
             Assert.Equal(expectedReason, details.Reason);
         }
 

--- a/test/OpenFeature.Contrib.Providers.Flagd.Test/FlagdProviderTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagd.Test/FlagdProviderTest.cs
@@ -179,7 +179,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
         }
 
         [Fact]
-        public void TestResolveBooleanValue()
+        public void TestResolveBooleanValueAsync()
         {
             var resp = new ResolveBooleanResponse
             {
@@ -203,7 +203,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             var flagdProvider = new FlagdProvider(rpcResolver);
 
             // resolve with default set to false to make sure we return what the grpc server gives us
-            var val = flagdProvider.ResolveBooleanValue("my-key", false);
+            var val = flagdProvider.ResolveBooleanValueAsync("my-key", false);
 
             Assert.True(val.Result.Value);
         }
@@ -229,7 +229,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             var rpcResolver = new RpcResolver(subGrpcClient, new FlagdConfig(), null, MakeChannel(), MakeProviderMetadata());
             var flagdProvider = new FlagdProvider(rpcResolver);
 
-            var val = flagdProvider.ResolveStringValue("my-key", "");
+            var val = flagdProvider.ResolveStringValueAsync("my-key", "");
 
             Assert.Equal("my-value", val.Result.Value);
         }
@@ -256,7 +256,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             var rpcResolver = new RpcResolver(subGrpcClient, new FlagdConfig(), null, MakeChannel(), MakeProviderMetadata());
             var flagdProvider = new FlagdProvider(rpcResolver);
 
-            var val = flagdProvider.ResolveIntegerValue("my-key", 0);
+            var val = flagdProvider.ResolveIntegerValueAsync("my-key", 0);
 
             Assert.Equal(10, val.Result.Value);
         }
@@ -283,7 +283,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             var rpcResolver = new RpcResolver(mockGrpcClient, new FlagdConfig(), null, MakeChannel(), MakeProviderMetadata());
             var flagdProvider = new FlagdProvider(rpcResolver);
 
-            var val = flagdProvider.ResolveDoubleValue("my-key", 0.0);
+            var val = flagdProvider.ResolveDoubleValueAsync("my-key", 0.0);
 
             Assert.Equal(10.0, val.Result.Value);
         }
@@ -313,7 +313,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             var rpcResolver = new RpcResolver(mockGrpcClient, new FlagdConfig(), null, MakeChannel(), MakeProviderMetadata());
             var flagdProvider = new FlagdProvider(rpcResolver);
 
-            var val = flagdProvider.ResolveStructureValue("my-key", null);
+            var val = flagdProvider.ResolveStructureValueAsync("my-key", null);
 
             Assert.True(val.Result.Value.AsStructure.ContainsKey("my-key"));
         }
@@ -342,7 +342,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             {
                 try
                 {
-                    await flagdProvider.ResolveBooleanValue("my-key", true);
+                    await flagdProvider.ResolveBooleanValueAsync("my-key", true);
                 }
                 catch (FeatureProviderException e)
                 {
@@ -378,7 +378,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             {
                 try
                 {
-                    await flagdProvider.ResolveBooleanValue("my-key", true);
+                    await flagdProvider.ResolveBooleanValueAsync("my-key", true);
                 }
                 catch (FeatureProviderException e)
                 {
@@ -414,7 +414,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             {
                 try
                 {
-                    await flagdProvider.ResolveBooleanValue("my-key", true);
+                    await flagdProvider.ResolveBooleanValueAsync("my-key", true);
                 }
                 catch (FeatureProviderException e)
                 {
@@ -450,7 +450,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             {
                 try
                 {
-                    await flagdProvider.ResolveBooleanValue("my-key", true);
+                    await flagdProvider.ResolveBooleanValueAsync("my-key", true);
                 }
                 catch (FeatureProviderException e)
                 {
@@ -526,38 +526,16 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
 
             var rpcResolver = new RpcResolver(mockGrpcClient, config, mockCache, MakeChannel(), MakeProviderMetadata());
             var flagdProvider = new FlagdProvider(rpcResolver);
-            await flagdProvider.Initialize(EvaluationContext.Empty);
+            await flagdProvider.InitializeAsync(EvaluationContext.Empty);
 
             // resolve with default set to false to make sure we return what the grpc server gives us
-            var val = flagdProvider.ResolveBooleanValue("my-key", false);
+            var val = flagdProvider.ResolveBooleanValueAsync("my-key", false);
             Assert.True(val.Result.Value);
 
             Assert.True(_autoResetEvent.WaitOne(10000));
             mockCache.Received(1).TryGet(Arg.Is<string>(s => s == "my-key"));
             mockCache.Received(1).Add(Arg.Is<string>(s => s == "my-key"), Arg.Any<object>());
             mockGrpcClient.Received(Quantity.AtLeastOne()).EventStream(Arg.Any<EventStreamRequest>(), null, null, CancellationToken.None);
-        }
-
-        [Fact]
-        public async Task TestResolverInit_Success_Ready()
-        {
-            var mockResolver = Substitute.For<Resolver.Resolver>();
-            mockResolver.Init().Returns(Task.CompletedTask);
-            var provider = new FlagdProvider(resolver: mockResolver);
-            await provider.Initialize(EvaluationContext.Empty);
-
-            Assert.Equal(ProviderStatus.Ready, provider.GetStatus());
-        }
-
-        [Fact]
-        public async Task TestResolverInit_Failure_Error()
-        {
-            var mockResolver = Substitute.For<Resolver.Resolver>();
-            mockResolver.Init().ThrowsAsync(new Exception("fake exception"));
-            var provider = new FlagdProvider(resolver: mockResolver);
-            await Assert.ThrowsAsync<AggregateException>(() => provider.Initialize(EvaluationContext.Empty));
-
-            Assert.Equal(ProviderStatus.Error, provider.GetStatus());
         }
 
         [Fact]
@@ -612,10 +590,10 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
 
             var rpcResolver = new RpcResolver(mockGrpcClient, config, mockCache, MakeChannel(), MakeProviderMetadata());
             var flagdProvider = new FlagdProvider(rpcResolver);
-            await flagdProvider.Initialize(EvaluationContext.Empty);
+            await flagdProvider.InitializeAsync(EvaluationContext.Empty);
 
             // resolve with default set to false to make sure we return what the grpc server gives us
-            var val = flagdProvider.ResolveBooleanValue("my-key", false);
+            var val = flagdProvider.ResolveBooleanValueAsync("my-key", false);
             Assert.True(val.Result.Value);
 
             // wait for the autoReset event to be fired before verifying the invocation of the mocked functions
@@ -708,16 +686,16 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
 
             var rpcResolver = new RpcResolver(mockGrpcClient, config, mockCache, MakeChannel(), MakeProviderMetadata());
             var flagdProvider = new FlagdProvider(rpcResolver);
-            await flagdProvider.Initialize(EvaluationContext.Empty);
+            await flagdProvider.InitializeAsync(EvaluationContext.Empty);
 
             // resolve with default set to false to make sure we return what the grpc server gives us
-            var val = flagdProvider.ResolveBooleanValue("my-key", false);
+            var val = flagdProvider.ResolveBooleanValueAsync("my-key", false);
             Assert.True(val.Result.Value);
 
             // set firstCall to true to make the mock EventStream return a configuration_change event
             firstCall = false;
 
-            val = flagdProvider.ResolveBooleanValue("my-key", false);
+            val = flagdProvider.ResolveBooleanValueAsync("my-key", false);
             Assert.True(val.Result.Value);
 
             Assert.True(_autoResetEvent.WaitOne(10000));
@@ -773,13 +751,13 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
 
             var rpcResolver = new InProcessResolver(mockGrpcClient, config, MakeChannel(), MakeProviderMetadata());
             var flagdProvider = new FlagdProvider(rpcResolver);
-            await flagdProvider.Initialize(EvaluationContext.Empty);
+            await flagdProvider.InitializeAsync(EvaluationContext.Empty);
 
             // resolve with default set to false to make sure we return what the grpc server gives us
             await Utils.AssertUntilAsync(
                 _ =>
                 {
-                    var val = flagdProvider.ResolveBooleanValue("staticBoolFlag", false);
+                    var val = flagdProvider.ResolveBooleanValueAsync("staticBoolFlag", false);
                     Assert.True(val.Result.Value);
                 });
 
@@ -831,13 +809,13 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
 
             var inProcessResolver = new InProcessResolver(mockGrpcClient, config, MakeChannel(), MakeProviderMetadata());
             var flagdProvider = new FlagdProvider(inProcessResolver);
-            await flagdProvider.Initialize(EvaluationContext.Empty);
+            await flagdProvider.InitializeAsync(EvaluationContext.Empty);
 
             // resolve with default set to false to make sure we return what the grpc server gives us
             await Utils.AssertUntilAsync(
                 _ =>
                 {
-                    Assert.ThrowsAsync<FlagNotFoundException>(() => flagdProvider.ResolveStringValue("unknown", "unknown"));
+                    Assert.ThrowsAsync<FlagNotFoundException>(() => flagdProvider.ResolveStringValueAsync("unknown", "unknown"));
                 });
 
             mockGrpcClient.Received(Quantity.AtLeastOne()).SyncFlags(Arg.Is<SyncFlagsRequest>(req => req.Selector == "source-selector"), null, null, CancellationToken.None);

--- a/test/OpenFeature.Contrib.Providers.Flagd.Test/JsonEvaluatorTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagd.Test/JsonEvaluatorTest.cs
@@ -20,7 +20,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
 
             jsonEvaluator.Sync(FlagConfigurationUpdateType.ADD, Utils.validFlagConfig);
 
-            var result = jsonEvaluator.ResolveBooleanValue("validFlag", false);
+            var result = jsonEvaluator.ResolveBooleanValueAsync("validFlag", false);
 
             Assert.True(result.Value);
 
@@ -35,7 +35,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
 
             jsonEvaluator.Sync(FlagConfigurationUpdateType.ALL, Utils.flags);
 
-            var result = jsonEvaluator.ResolveStringValue("staticStringFlag", "");
+            var result = jsonEvaluator.ResolveStringValueAsync("staticStringFlag", "");
 
             Assert.Equal("#CC0000", result.Value);
             Assert.Equal("red", result.Variant);
@@ -59,7 +59,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             builder
               .Set("color", "yellow");
 
-            var result = jsonEvaluator.ResolveBooleanValue("targetingBoolFlag", false, builder.Build());
+            var result = jsonEvaluator.ResolveBooleanValueAsync("targetingBoolFlag", false, builder.Build());
 
             Assert.True(result.Value);
             Assert.Equal("bool1", result.Variant);
@@ -80,7 +80,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
 
             var builder = EvaluationContext.Builder();
 
-            var result = jsonEvaluator.ResolveBooleanValue("targetingBoolFlagUsingFlagdProperty", false, builder.Build());
+            var result = jsonEvaluator.ResolveBooleanValueAsync("targetingBoolFlagUsingFlagdProperty", false, builder.Build());
 
             Assert.True(result.Value);
             Assert.Equal("bool1", result.Variant);
@@ -101,7 +101,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
 
             var builder = EvaluationContext.Builder();
 
-            var result = jsonEvaluator.ResolveBooleanValue("targetingBoolFlagUsingFlagdPropertyTimestamp", false, builder.Build());
+            var result = jsonEvaluator.ResolveBooleanValueAsync("targetingBoolFlagUsingFlagdPropertyTimestamp", false, builder.Build());
 
             Assert.True(result.Value);
             Assert.Equal("bool1", result.Variant);
@@ -119,7 +119,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
 
             var builder = EvaluationContext.Builder().Set("email", "test@faas.com");
 
-            var result = jsonEvaluator.ResolveBooleanValue("targetingBoolFlagUsingSharedEvaluator", false, builder.Build());
+            var result = jsonEvaluator.ResolveBooleanValueAsync("targetingBoolFlagUsingSharedEvaluator", false, builder.Build());
 
             Assert.True(result.Value);
             Assert.Equal("bool1", result.Variant);
@@ -137,7 +137,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
 
             var builder = EvaluationContext.Builder().Set("email", "test@faas.com");
 
-            var result = jsonEvaluator.ResolveBooleanValue("targetingBoolFlagUsingSharedEvaluatorReturningBoolType", false, builder.Build());
+            var result = jsonEvaluator.ResolveBooleanValueAsync("targetingBoolFlagUsingSharedEvaluatorReturningBoolType", false, builder.Build());
 
             Assert.True(result.Value);
             Assert.Equal("true", result.Variant);
@@ -155,7 +155,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
 
             var builder = EvaluationContext.Builder();
 
-            Assert.Throws<FeatureProviderException>(() => jsonEvaluator.ResolveBooleanValue("targetingBoolFlagWithMissingDefaultVariant", false, builder.Build()));
+            Assert.Throws<FeatureProviderException>(() => jsonEvaluator.ResolveBooleanValueAsync("targetingBoolFlagWithMissingDefaultVariant", false, builder.Build()));
         }
 
         [Fact]
@@ -169,7 +169,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
 
             var builder = EvaluationContext.Builder();
 
-            Assert.Throws<FeatureProviderException>(() => jsonEvaluator.ResolveBooleanValue("targetingBoolFlagWithUnexpectedVariantType", false, builder.Build()));
+            Assert.Throws<FeatureProviderException>(() => jsonEvaluator.ResolveBooleanValueAsync("targetingBoolFlagWithUnexpectedVariantType", false, builder.Build()));
         }
 
         [Fact]
@@ -188,7 +188,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             builder
               .Set("color", "yellow");
 
-            var result = jsonEvaluator.ResolveStringValue("targetingStringFlag", "", builder.Build());
+            var result = jsonEvaluator.ResolveStringValueAsync("targetingStringFlag", "", builder.Build());
 
             Assert.Equal("my-string", result.Value);
             Assert.Equal("str1", result.Variant);
@@ -211,7 +211,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             builder
               .Set("color", "yellow");
 
-            var result = jsonEvaluator.ResolveDoubleValue("targetingFloatFlag", 0, builder.Build());
+            var result = jsonEvaluator.ResolveDoubleValueAsync("targetingFloatFlag", 0, builder.Build());
 
             Assert.Equal(100, result.Value);
             Assert.Equal("number1", result.Variant);
@@ -234,7 +234,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             builder
               .Set("color", "yellow");
 
-            var result = jsonEvaluator.ResolveIntegerValue("targetingNumberFlag", 0, builder.Build());
+            var result = jsonEvaluator.ResolveIntegerValueAsync("targetingNumberFlag", 0, builder.Build());
 
             Assert.Equal(100, result.Value);
             Assert.Equal("number1", result.Variant);
@@ -257,7 +257,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             builder
               .Set("color", "yellow");
 
-            var result = jsonEvaluator.ResolveStructureValue("targetingObjectFlag", null, builder.Build());
+            var result = jsonEvaluator.ResolveStructureValueAsync("targetingObjectFlag", null, builder.Build());
 
             Assert.True(result.Value.AsStructure.AsDictionary()["key"].AsBoolean);
             Assert.Equal("object1", result.Variant);
@@ -280,7 +280,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             builder
                 .Set("color", "yellow");
 
-            Assert.Throws<FeatureProviderException>(() => jsonEvaluator.ResolveBooleanValue("disabledFlag", false, builder.Build()));
+            Assert.Throws<FeatureProviderException>(() => jsonEvaluator.ResolveBooleanValueAsync("disabledFlag", false, builder.Build()));
         }
 
         [Fact]
@@ -299,7 +299,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             builder
                 .Set("color", "yellow");
 
-            Assert.Throws<FeatureProviderException>(() => jsonEvaluator.ResolveBooleanValue("missingFlag", false, builder.Build()));
+            Assert.Throws<FeatureProviderException>(() => jsonEvaluator.ResolveBooleanValueAsync("missingFlag", false, builder.Build()));
         }
 
         [Fact]
@@ -318,7 +318,7 @@ namespace OpenFeature.Contrib.Providers.Flagd.Test
             builder
                 .Set("color", "yellow");
 
-            Assert.Throws<FeatureProviderException>(() => jsonEvaluator.ResolveBooleanValue("staticStringFlag", false, builder.Build()));
+            Assert.Throws<FeatureProviderException>(() => jsonEvaluator.ResolveBooleanValueAsync("staticStringFlag", false, builder.Build()));
         }
     }
 }

--- a/test/OpenFeature.Contrib.Providers.Flagsmith.Test/FlagsmithProviderTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagsmith.Test/FlagsmithProviderTest.cs
@@ -65,7 +65,7 @@ namespace OpenFeature.Contrib.Providers.Flagsmith.Test
             var date = DateTime.Now;
             flags.GetFeatureValue("example-feature").Returns("true");
             flags.IsFeatureEnabled("example-feature").Returns(true);
-            flagsmithClient.GetIdentityFlags("233", Arg.Is<List<ITrait>>(x => x.Count == 6 && x.Any(c => c.GetTraitKey() == "key1"))).Returns(flags);
+            flagsmithClient.GetIdentityFlags("233", Arg.Is<List<ITrait>>(x => x.Count > 6 && x.Any(c => c.GetTraitKey() == "key1"))).Returns(flags);
 
             var providerConfig = GetDefaultFlagsmithProviderConfigurationConfiguration();
             var flagsmithProvider = new FlagsmithProvider(providerConfig, flagsmithClient);
@@ -79,7 +79,7 @@ namespace OpenFeature.Contrib.Providers.Flagsmith.Test
                 .Set("key6", 1.0)
                 .SetTargetingKey("233");
             // Act
-            var result = await flagsmithProvider.ResolveBooleanValue("example-feature", false, contextBuilder.Build());
+            var result = await flagsmithProvider.ResolveBooleanValueAsync("example-feature", false, contextBuilder.Build());
 
             // Assert
             Assert.True(result.Value);
@@ -107,7 +107,7 @@ namespace OpenFeature.Contrib.Providers.Flagsmith.Test
         [InlineData(false, true, "false", false, "DISABLED", false)]
         [InlineData(true, false, "false", false, null, false)]
         [InlineData(false, false, "false", false, null, false)]
-        public async Task GetBooleanValue_ForEnabledFeatureWithValidFormatAndSettedConfigValue_ReturnExpectedResult(
+        public async Task GetBooleanValueAsync_ForEnabledFeatureWithValidFormatAndSettedConfigValue_ReturnExpectedResult(
             bool defaultValue,
             bool enabledValueConfig,
             string settedValue,
@@ -127,7 +127,7 @@ namespace OpenFeature.Contrib.Providers.Flagsmith.Test
             var flagsmithProvider = new FlagsmithProvider(providerConfig, flagsmithClient);
 
             // Act
-            var result = await flagsmithProvider.ResolveBooleanValue("example-feature", defaultValue);
+            var result = await flagsmithProvider.ResolveBooleanValueAsync("example-feature", defaultValue);
 
             // Assert
             Assert.Equal(expectedResult, result.Value);
@@ -137,7 +137,7 @@ namespace OpenFeature.Contrib.Providers.Flagsmith.Test
         }
 
         [Fact]
-        public async Task GetBooleanValue_ForEnabledFeatureWithWrongFormatValue_ThrowsTypeMismatch()
+        public async Task GetBooleanValueAsync_ForEnabledFeatureWithWrongFormatValue_ThrowsTypeMismatch()
         {
             // Arrange
             var flagsmithClient = Substitute.For<IFlagsmithClient>();
@@ -152,12 +152,12 @@ namespace OpenFeature.Contrib.Providers.Flagsmith.Test
             var flagsmithProvider = new FlagsmithProvider(providerConfig, flagsmithClient);
 
             // Act and Assert
-            await Assert.ThrowsAsync<TypeMismatchException>(() => flagsmithProvider.ResolveBooleanValue("example-feature", true));
+            await Assert.ThrowsAsync<TypeMismatchException>(() => flagsmithProvider.ResolveBooleanValueAsync("example-feature", true));
         }
 
 
         [Fact]
-        public async Task GetDoubleValue_ForEnabledFeatureWithValidFormat_ReturnCorrectValue()
+        public async Task GetDoubleValueAsync_ForEnabledFeatureWithValidFormat_ReturnCorrectValue()
         {
             // Arrange
             var flagsmithClient = Substitute.For<IFlagsmithClient>();
@@ -171,7 +171,7 @@ namespace OpenFeature.Contrib.Providers.Flagsmith.Test
             var flagsmithProvider = new FlagsmithProvider(providerConfig, flagsmithClient);
 
             // Act
-            var result = await flagsmithProvider.ResolveDoubleValue("example-feature", 32.22);
+            var result = await flagsmithProvider.ResolveDoubleValueAsync("example-feature", 32.22);
 
             // Assert
             Assert.Equal(32.334, result.Value);
@@ -182,7 +182,7 @@ namespace OpenFeature.Contrib.Providers.Flagsmith.Test
 
 
         [Fact]
-        public async Task GetDoubleValue_ForDisabledFeatureWithValidFormat_ReturnDefaultValue()
+        public async Task GetDoubleValueAsync_ForDisabledFeatureWithValidFormat_ReturnDefaultValue()
         {
             // Arrange
             var flagsmithClient = Substitute.For<IFlagsmithClient>();
@@ -195,7 +195,7 @@ namespace OpenFeature.Contrib.Providers.Flagsmith.Test
             var flagsmithProvider = new FlagsmithProvider(providerConfig, flagsmithClient);
 
             // Act
-            var result = await flagsmithProvider.ResolveDoubleValue("example-feature", -32.22);
+            var result = await flagsmithProvider.ResolveDoubleValueAsync("example-feature", -32.22);
 
             // Assert
             Assert.Equal(-32.22, result.Value);
@@ -205,7 +205,7 @@ namespace OpenFeature.Contrib.Providers.Flagsmith.Test
         }
 
         [Fact]
-        public async Task GetDoubleValue_ForEnabledFeatureWithWrongFormatValue_ThrowsTypeMismatch()
+        public async Task GetDoubleValueAsync_ForEnabledFeatureWithWrongFormatValue_ThrowsTypeMismatch()
         {
             // Arrange
             var flagsmithClient = Substitute.For<IFlagsmithClient>();
@@ -218,13 +218,13 @@ namespace OpenFeature.Contrib.Providers.Flagsmith.Test
             var flagsmithProvider = new FlagsmithProvider(providerConfig, flagsmithClient);
 
             // Act and Assert
-            await Assert.ThrowsAsync<TypeMismatchException>(() => flagsmithProvider.ResolveDoubleValue("example-feature", 2222.22133));
+            await Assert.ThrowsAsync<TypeMismatchException>(() => flagsmithProvider.ResolveDoubleValueAsync("example-feature", 2222.22133));
         }
 
 
 
         [Fact]
-        public async Task GetStringValue_ForEnabledFeatureWithValidFormat_ReturnCorrectValue()
+        public async Task GetStringValueAsync_ForEnabledFeatureWithValidFormat_ReturnCorrectValue()
         {
             // Arrange
             var flagsmithClient = Substitute.For<IFlagsmithClient>();
@@ -237,7 +237,7 @@ namespace OpenFeature.Contrib.Providers.Flagsmith.Test
             var flagsmithProvider = new FlagsmithProvider(providerConfig, flagsmithClient);
 
             // Act
-            var result = await flagsmithProvider.ResolveStringValue("example-feature", "example");
+            var result = await flagsmithProvider.ResolveStringValueAsync("example-feature", "example");
 
             // Assert
             Assert.Equal("example", result.Value);
@@ -248,7 +248,7 @@ namespace OpenFeature.Contrib.Providers.Flagsmith.Test
 
 
         [Fact]
-        public async Task GetStringValue_ForDisabledFeatureWithValidFormat_ReturnDefaultValue()
+        public async Task GetStringValueAsync_ForDisabledFeatureWithValidFormat_ReturnDefaultValue()
         {
             // Arrange
             var flagsmithClient = Substitute.For<IFlagsmithClient>();
@@ -261,7 +261,7 @@ namespace OpenFeature.Contrib.Providers.Flagsmith.Test
             var flagsmithProvider = new FlagsmithProvider(providerConfig, flagsmithClient);
 
             // Act
-            var result = await flagsmithProvider.ResolveStringValue("example-feature", "3333a");
+            var result = await flagsmithProvider.ResolveStringValueAsync("example-feature", "3333a");
 
             // Assert
             Assert.Equal("3333a", result.Value);
@@ -285,7 +285,7 @@ namespace OpenFeature.Contrib.Providers.Flagsmith.Test
             var flagsmithProvider = new FlagsmithProvider(providerConfig, flagsmithClient);
 
             // Act
-            var result = await flagsmithProvider.ResolveIntegerValue("example-feature", 32);
+            var result = await flagsmithProvider.ResolveIntegerValueAsync("example-feature", 32);
 
             // Assert
             Assert.Equal(232, result.Value);
@@ -308,7 +308,7 @@ namespace OpenFeature.Contrib.Providers.Flagsmith.Test
             var flagsmithProvider = new FlagsmithProvider(providerConfig, flagsmithClient);
 
             // Act
-            var result = await flagsmithProvider.ResolveIntegerValue("example-feature", -32);
+            var result = await flagsmithProvider.ResolveIntegerValueAsync("example-feature", -32);
 
             // Assert
             Assert.Equal(-32, result.Value);
@@ -331,11 +331,11 @@ namespace OpenFeature.Contrib.Providers.Flagsmith.Test
             var flagsmithProvider = new FlagsmithProvider(providerConfig, flagsmithClient);
 
             // Act and Assert
-            await Assert.ThrowsAsync<TypeMismatchException>(() => flagsmithProvider.ResolveIntegerValue("example-feature", 2222));
+            await Assert.ThrowsAsync<TypeMismatchException>(() => flagsmithProvider.ResolveIntegerValueAsync("example-feature", 2222));
         }
 
         [Fact]
-        public async Task GetStructureValue_ForEnabledFeatureWithValidFormat_ReturnCorrectValue()
+        public async Task GetStructureValueAsync_ForEnabledFeatureWithValidFormat_ReturnCorrectValue()
         {
             // Arrange
             var flagsmithClient = Substitute.For<IFlagsmithClient>();
@@ -382,7 +382,7 @@ namespace OpenFeature.Contrib.Providers.Flagsmith.Test
             // Act
             var defaultObject = new Value(Structure.Empty);
 
-            var result = await flagsmithProvider.ResolveStructureValue("example-feature", defaultObject);
+            var result = await flagsmithProvider.ResolveStructureValueAsync("example-feature", defaultObject);
 
             // Assert
             var glossary = result.Value.AsStructure.GetValue("glossary");
@@ -409,7 +409,7 @@ namespace OpenFeature.Contrib.Providers.Flagsmith.Test
         }
 
         [Fact]
-        public async Task GetStructureValue_ForDisabledFeatureWithValidFormat_ReturnDefaultValue()
+        public async Task GetStructureValueAsync_ForDisabledFeatureWithValidFormat_ReturnDefaultValue()
         {
             // Arrange
             var flagsmithClient = Substitute.For<IFlagsmithClient>();
@@ -423,7 +423,7 @@ namespace OpenFeature.Contrib.Providers.Flagsmith.Test
             var flagsmithProvider = new FlagsmithProvider(providerConfig, flagsmithClient);
 
             // Act
-            var result = await flagsmithProvider.ResolveStructureValue("example-feature", defaultObject);
+            var result = await flagsmithProvider.ResolveStructureValueAsync("example-feature", defaultObject);
 
             // Assert
             Assert.Equal(defaultObject, result.Value);
@@ -433,7 +433,7 @@ namespace OpenFeature.Contrib.Providers.Flagsmith.Test
         }
 
         [Fact]
-        public async Task GetStructureValue_ForEnabledFeatureWithWrongFormatValue_ThrowsTypeMismatch()
+        public async Task GetStructureValueAsync_ForEnabledFeatureWithWrongFormatValue_ThrowsTypeMismatch()
         {
             // Arrange
             var flagsmithClient = Substitute.For<IFlagsmithClient>();
@@ -447,7 +447,7 @@ namespace OpenFeature.Contrib.Providers.Flagsmith.Test
             var flagsmithProvider = new FlagsmithProvider(providerConfig, flagsmithClient);
 
             // Act and Assert
-            await Assert.ThrowsAsync<TypeMismatchException>(() => flagsmithProvider.ResolveStructureValue("example-feature", defaultObject));
+            await Assert.ThrowsAsync<TypeMismatchException>(() => flagsmithProvider.ResolveStructureValueAsync("example-feature", defaultObject));
         }
     }
 }

--- a/test/OpenFeature.Contrib.Providers.GOFeatureFlag.Test/GoFeatureFlagProviderTest.cs
+++ b/test/OpenFeature.Contrib.Providers.GOFeatureFlag.Test/GoFeatureFlagProviderTest.cs
@@ -145,7 +145,7 @@ public class GoFeatureFlagProviderTest
         });
         await Api.Instance.SetProviderAsync(g);
         var client = Api.Instance.GetClient("test-client");
-        var res = client.GetBooleanDetails("fail_500", false, _defaultEvaluationCtx);
+        var res = client.GetBooleanDetailsAsync("fail_500", false, _defaultEvaluationCtx);
         Assert.NotNull(res.Result);
         Assert.False(res.Result.Value);
         Assert.Equal(ErrorType.General, res.Result.ErrorType);
@@ -163,7 +163,7 @@ public class GoFeatureFlagProviderTest
         });
         await Api.Instance.SetProviderAsync(g);
         var client = Api.Instance.GetClient("test-client");
-        var res = client.GetBooleanDetails("api_key_missing", false, _defaultEvaluationCtx);
+        var res = client.GetBooleanDetailsAsync("api_key_missing", false, _defaultEvaluationCtx);
         Assert.NotNull(res.Result);
         Assert.False(res.Result.Value);
         Assert.Equal(Reason.Error, res.Result.Reason);
@@ -182,7 +182,7 @@ public class GoFeatureFlagProviderTest
         });
         await Api.Instance.SetProviderAsync(g);
         var client = Api.Instance.GetClient("test-client");
-        var res = client.GetBooleanDetails("invalid_api_key", false, _defaultEvaluationCtx);
+        var res = client.GetBooleanDetailsAsync("invalid_api_key", false, _defaultEvaluationCtx);
         Assert.NotNull(res.Result);
         Assert.False(res.Result.Value);
         Assert.Equal(Reason.Error, res.Result.Reason);
@@ -200,7 +200,7 @@ public class GoFeatureFlagProviderTest
         });
         await Api.Instance.SetProviderAsync(g);
         var client = Api.Instance.GetClient("test-client");
-        var res = client.GetBooleanDetails("flag_not_found", false, _defaultEvaluationCtx);
+        var res = client.GetBooleanDetailsAsync("flag_not_found", false, _defaultEvaluationCtx);
         Assert.NotNull(res.Result);
         Assert.False(res.Result.Value);
         Assert.Equal(ErrorType.FlagNotFound, res.Result.ErrorType);
@@ -218,7 +218,7 @@ public class GoFeatureFlagProviderTest
         });
         await Api.Instance.SetProviderAsync(g);
         var client = Api.Instance.GetClient("test-client");
-        var res = client.GetBooleanDetails("string_key", false, _defaultEvaluationCtx);
+        var res = client.GetBooleanDetailsAsync("string_key", false, _defaultEvaluationCtx);
         Assert.NotNull(res.Result);
         Assert.False(res.Result.Value);
         Assert.Equal(ErrorType.TypeMismatch, res.Result.ErrorType);
@@ -236,7 +236,7 @@ public class GoFeatureFlagProviderTest
         });
         await Api.Instance.SetProviderAsync(g);
         var client = Api.Instance.GetClient("test-client");
-        var res = client.GetBooleanDetails("bool_targeting_match", false, _defaultEvaluationCtx);
+        var res = client.GetBooleanDetailsAsync("bool_targeting_match", false, _defaultEvaluationCtx);
         Assert.NotNull(res.Result);
         Assert.True(res.Result.Value);
         Assert.Equal(ErrorType.None, res.Result.ErrorType);
@@ -255,7 +255,7 @@ public class GoFeatureFlagProviderTest
         });
         await Api.Instance.SetProviderAsync(g);
         var client = Api.Instance.GetClient("test-client");
-        var res = client.GetBooleanDetails("unknown_reason", false, _defaultEvaluationCtx);
+        var res = client.GetBooleanDetailsAsync("unknown_reason", false, _defaultEvaluationCtx);
         Assert.NotNull(res.Result);
         Assert.True(res.Result.Value);
         Assert.Equal(ErrorType.None, res.Result.ErrorType);
@@ -274,7 +274,7 @@ public class GoFeatureFlagProviderTest
         });
         await Api.Instance.SetProviderAsync(g);
         var client = Api.Instance.GetClient("test-client");
-        var res = client.GetBooleanDetails("disabled", false, _defaultEvaluationCtx);
+        var res = client.GetBooleanDetailsAsync("disabled", false, _defaultEvaluationCtx);
         Assert.NotNull(res.Result);
         Assert.False(res.Result.Value);
         Assert.Equal(Reason.Disabled, res.Result.Reason);
@@ -291,7 +291,7 @@ public class GoFeatureFlagProviderTest
         });
         await Api.Instance.SetProviderAsync(g);
         var client = Api.Instance.GetClient("test-client");
-        var res = client.GetStringDetails("bool_targeting_match", "default", _defaultEvaluationCtx);
+        var res = client.GetStringDetailsAsync("bool_targeting_match", "default", _defaultEvaluationCtx);
         Assert.NotNull(res.Result);
         Assert.Equal("default", res.Result.Value);
         Assert.Equal(ErrorType.TypeMismatch, res.Result.ErrorType);
@@ -309,7 +309,7 @@ public class GoFeatureFlagProviderTest
         });
         await Api.Instance.SetProviderAsync(g);
         var client = Api.Instance.GetClient("test-client");
-        var res = client.GetStringDetails("string_key", "defaultValue", _defaultEvaluationCtx);
+        var res = client.GetStringDetailsAsync("string_key", "defaultValue", _defaultEvaluationCtx);
         Assert.NotNull(res.Result);
         Assert.Equal("CC0000", res.Result.Value);
         Assert.Equal(ErrorType.None, res.Result.ErrorType);
@@ -328,7 +328,7 @@ public class GoFeatureFlagProviderTest
         });
         await Api.Instance.SetProviderAsync(g);
         var client = Api.Instance.GetClient("test-client");
-        var res = client.GetStringDetails("disabled_string", "defaultValue", _defaultEvaluationCtx);
+        var res = client.GetStringDetailsAsync("disabled_string", "defaultValue", _defaultEvaluationCtx);
         Assert.NotNull(res.Result);
         Assert.Equal("defaultValue", res.Result.Value);
         Assert.Equal(Reason.Disabled, res.Result.Reason);
@@ -345,7 +345,7 @@ public class GoFeatureFlagProviderTest
         });
         await Api.Instance.SetProviderAsync(g);
         var client = Api.Instance.GetClient("test-client");
-        var res = client.GetIntegerDetails("string_key", 200, _defaultEvaluationCtx);
+        var res = client.GetIntegerDetailsAsync("string_key", 200, _defaultEvaluationCtx);
         Assert.NotNull(res.Result);
         Assert.Equal(200, res.Result.Value);
         Assert.Equal(ErrorType.TypeMismatch, res.Result.ErrorType);
@@ -363,7 +363,7 @@ public class GoFeatureFlagProviderTest
         });
         await Api.Instance.SetProviderAsync(g);
         var client = Api.Instance.GetClient("test-client");
-        var res = client.GetIntegerDetails("integer_key", 1200, _defaultEvaluationCtx);
+        var res = client.GetIntegerDetailsAsync("integer_key", 1200, _defaultEvaluationCtx);
         Assert.NotNull(res.Result);
         Assert.Equal(100, res.Result.Value);
         Assert.Equal(ErrorType.None, res.Result.ErrorType);
@@ -382,7 +382,7 @@ public class GoFeatureFlagProviderTest
         });
         await Api.Instance.SetProviderAsync(g);
         var client = Api.Instance.GetClient("test-client");
-        var res = client.GetIntegerDetails("disabled_integer", 1225, _defaultEvaluationCtx);
+        var res = client.GetIntegerDetailsAsync("disabled_integer", 1225, _defaultEvaluationCtx);
         Assert.NotNull(res.Result);
         Assert.Equal(1225, res.Result.Value);
         Assert.Equal(Reason.Disabled, res.Result.Reason);
@@ -399,7 +399,7 @@ public class GoFeatureFlagProviderTest
         });
         await Api.Instance.SetProviderAsync(g);
         var client = Api.Instance.GetClient("test-client");
-        var res = client.GetIntegerDetails("double_key", 200, _defaultEvaluationCtx);
+        var res = client.GetIntegerDetailsAsync("double_key", 200, _defaultEvaluationCtx);
         Assert.NotNull(res.Result);
         Assert.Equal(200, res.Result.Value);
         Assert.Equal(ErrorType.TypeMismatch, res.Result.ErrorType);
@@ -417,7 +417,7 @@ public class GoFeatureFlagProviderTest
         });
         await Api.Instance.SetProviderAsync(g);
         var client = Api.Instance.GetClient("test-client");
-        var res = client.GetDoubleDetails("double_key", 1200.25, _defaultEvaluationCtx);
+        var res = client.GetDoubleDetailsAsync("double_key", 1200.25, _defaultEvaluationCtx);
         Assert.NotNull(res.Result);
         Assert.Equal(100.25, res.Result.Value);
         Assert.Equal(ErrorType.None, res.Result.ErrorType);
@@ -436,7 +436,7 @@ public class GoFeatureFlagProviderTest
         });
         await Api.Instance.SetProviderAsync(g);
         var client = Api.Instance.GetClient("test-client");
-        var res = client.GetDoubleDetails("disabled_double", 1225.34, _defaultEvaluationCtx);
+        var res = client.GetDoubleDetailsAsync("disabled_double", 1225.34, _defaultEvaluationCtx);
         Assert.NotNull(res.Result);
         Assert.Equal(1225.34, res.Result.Value);
         Assert.Equal(Reason.Disabled, res.Result.Reason);
@@ -453,7 +453,7 @@ public class GoFeatureFlagProviderTest
         });
         await Api.Instance.SetProviderAsync(g);
         var client = Api.Instance.GetClient("test-client");
-        var res = client.GetObjectDetails("object_key", null, _defaultEvaluationCtx);
+        var res = client.GetObjectDetailsAsync("object_key", null, _defaultEvaluationCtx);
         Assert.NotNull(res.Result);
         var want = JsonSerializer.Serialize(new Value(new Structure(new Dictionary<string, Value>
         {
@@ -477,7 +477,7 @@ public class GoFeatureFlagProviderTest
         });
         await Api.Instance.SetProviderAsync(g);
         var client = Api.Instance.GetClient("test-client");
-        var res = client.GetObjectDetails("string_key", null, _defaultEvaluationCtx);
+        var res = client.GetObjectDetailsAsync("string_key", null, _defaultEvaluationCtx);
         Assert.NotNull(res.Result);
         Assert.Equal(new Value("CC0000").AsString, res.Result.Value.AsString);
         Assert.Equal(ErrorType.None, res.Result.ErrorType);
@@ -496,7 +496,7 @@ public class GoFeatureFlagProviderTest
         });
         await Api.Instance.SetProviderAsync(g);
         var client = Api.Instance.GetClient("test-client");
-        var res = client.GetObjectDetails("disabled_object", new Value("default"), _defaultEvaluationCtx);
+        var res = client.GetObjectDetailsAsync("disabled_object", new Value("default"), _defaultEvaluationCtx);
         Assert.NotNull(res.Result);
         Assert.Equal(new Value("default").AsString, res.Result.Value.AsString);
         Assert.Equal(Reason.Disabled, res.Result.Reason);
@@ -514,7 +514,7 @@ public class GoFeatureFlagProviderTest
         });
         await Api.Instance.SetProviderAsync(g);
         var client = Api.Instance.GetClient("test-client");
-        var res = client.GetStringDetails("list_key", "empty", EvaluationContext.Empty);
+        var res = client.GetStringDetailsAsync("list_key", "empty", EvaluationContext.Empty);
         Assert.NotNull(res.Result);
         Assert.Equal("empty", res.Result.Value);
         Assert.Equal(ErrorType.InvalidContext, res.Result.ErrorType);
@@ -532,7 +532,7 @@ public class GoFeatureFlagProviderTest
         });
         await Api.Instance.SetProviderAsync(g);
         var client = Api.Instance.GetClient("test-client");
-        var res = client.GetObjectDetails("list_key", null, _defaultEvaluationCtx);
+        var res = client.GetObjectDetailsAsync("list_key", null, _defaultEvaluationCtx);
         Assert.NotNull(res.Result);
         var want = JsonSerializer.Serialize(new Value(new List<Value>
             { new("test"), new("test1"), new("test2"), new("false"), new("test3") }));
@@ -553,7 +553,7 @@ public class GoFeatureFlagProviderTest
         });
         await Api.Instance.SetProviderAsync(g);
         var client = Api.Instance.GetClient("test-client");
-        var res = client.GetObjectDetails("does_not_exists", new Value("default"), _defaultEvaluationCtx);
+        var res = client.GetObjectDetailsAsync("does_not_exists", new Value("default"), _defaultEvaluationCtx);
         Assert.NotNull(res.Result);
         Assert.Equal(new Value("default").AsString, res.Result.Value.AsString);
         Assert.Equal(Reason.Error, res.Result.Reason);

--- a/test/OpenFeature.Contrib.Providers.Statsig.Test/StatsigProviderTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Statsig.Test/StatsigProviderTest.cs
@@ -15,54 +15,46 @@ public class StatsigProviderTest
         statsigProvider = new StatsigProvider("secret-", new StatsigServerOptions() { LocalMode = true });
     }
 
-    [Fact]
-    public async Task StatsigProvider_Initialized_HasCorrectStatusAsync()
-    {
-        Assert.Equal(ProviderStatus.NotReady, statsigProvider.GetStatus());
-        await statsigProvider.Initialize(null);
-        Assert.Equal(ProviderStatus.Ready, statsigProvider.GetStatus());
-    }
-
     [Theory]
     [InlineAutoData(true, true)]
     [InlineAutoData(false, false)]
-    public async Task GetBooleanValue_ForFeatureWithContext(bool flagValue, bool expectedValue, string userId, string flagName)
+    public async Task GetBooleanValueAsync_ForFeatureWithContext(bool flagValue, bool expectedValue, string userId, string flagName)
     {
         // Arrange
-        await statsigProvider.Initialize(null);
+        await statsigProvider.InitializeAsync(null);
         var ec = EvaluationContext.Builder().SetTargetingKey(userId).Build();
         statsigProvider.ServerDriver.OverrideGate(flagName, flagValue, userId);
 
         // Act & Assert
-        Assert.Equal(expectedValue, statsigProvider.ResolveBooleanValue(flagName, false, ec).Result.Value);
+        Assert.Equal(expectedValue, statsigProvider.ResolveBooleanValueAsync(flagName, false, ec).Result.Value);
     }
 
     [Theory]
     [InlineAutoData(true, false)]
     [InlineAutoData(false, false)]
-    public async Task GetBooleanValue_ForFeatureWithNoContext_ReturnsDefaultValue(bool flagValue, bool defaultValue, string flagName)
+    public async Task GetBooleanValueAsync_ForFeatureWithNoContext_ReturnsDefaultValue(bool flagValue, bool defaultValue, string flagName)
     {
         // Arrange
-        await statsigProvider.Initialize(null);
+        await statsigProvider.InitializeAsync(null);
         statsigProvider.ServerDriver.OverrideGate(flagName, flagValue);
 
         // Act & Assert
-        Assert.Equal(defaultValue, statsigProvider.ResolveBooleanValue(flagName, defaultValue).Result.Value);
+        Assert.Equal(defaultValue, statsigProvider.ResolveBooleanValueAsync(flagName, defaultValue).Result.Value);
     }
 
     [Theory]
     [AutoData]
     [InlineAutoData(false)]
     [InlineAutoData(true)]
-    public async Task GetBooleanValue_ForFeatureWithDefault(bool defaultValue, string flagName, string userId)
+    public async Task GetBooleanValueAsync_ForFeatureWithDefault(bool defaultValue, string flagName, string userId)
     {
         // Arrange
-        await statsigProvider.Initialize(null);
+        await statsigProvider.InitializeAsync(null);
 
         var ec = EvaluationContext.Builder().SetTargetingKey(userId).Build();
 
         // Act
-        var result = await statsigProvider.ResolveBooleanValue(flagName, defaultValue, ec);
+        var result = await statsigProvider.ResolveBooleanValueAsync(flagName, defaultValue, ec);
 
         //Assert
         Assert.Equal(defaultValue, result.Value);
@@ -79,7 +71,7 @@ public class StatsigProviderTest
         var tasks = new Task[numberOfThreads];
         for (int i = 0; i < numberOfThreads; i++)
         {
-            tasks[i] = concurrencyTestClass.Initialize(null);
+            tasks[i] = concurrencyTestClass.InitializeAsync(null);
         }
 
         await Task.WhenAll(tasks);


### PR DESCRIPTION
This PR updates the entire monorepo to use the 2.0+ version of the SDK, and for all the artifacts to require it.

There was no substantial changes besides the expected method renames, etc.