### PR TITLE
fix: Revise ConfigCat provider

### DIFF
--- a/src/OpenFeature.Contrib.Providers.ConfigCat/ConfigCatProvider.cs
+++ b/src/OpenFeature.Contrib.Providers.ConfigCat/ConfigCatProvider.cs
@@ -30,6 +30,19 @@ namespace OpenFeature.Contrib.ConfigCat
         }
 
         /// <inheritdoc/>
+        public override Task InitializeAsync(EvaluationContext context, CancellationToken cancellationToken = default)
+        {
+            return Client.WaitForReadyAsync(cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public override Task ShutdownAsync(CancellationToken cancellationToken = default)
+        {
+            Client.Dispose();
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc/>
         public override Metadata GetMetadata()
         {
             return new Metadata(Name);

--- a/src/OpenFeature.Contrib.Providers.ConfigCat/OpenFeature.Contrib.Providers.ConfigCat.csproj
+++ b/src/OpenFeature.Contrib.Providers.ConfigCat/OpenFeature.Contrib.Providers.ConfigCat.csproj
@@ -16,6 +16,6 @@
     </AssemblyAttribute>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ConfigCat.Client" Version="9.2.0"/>
+    <PackageReference Include="ConfigCat.Client" Version="9.3.1"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## This PR

As part of our official support for ConfigCat OpenFeatures providers, I revised the .NET provider and am proposing the following improvements and corrections:
* Let's implement `InitializeAsync` (so feature flag evaluation after awaiting `SetProviderAsync` will succeed) and `ShutdownAsync` (so the underlying client is disposed, i.e. the polling loop is stopped as soon as it's not needed any more).
* `UserBuilder` made some unnecessary heap memory allocations (e.g. when converting attribute keys to upper case). Let's eliminate these. (As feature flag evaluation can occur on hot paths, we should aim to minimize allocations to put as little pressure on the GC as possible.)
* When `id` or `identifier` is not specified in the evaluation context, a random user id is generated (a guid). I advise against this as it can lead to confusing user experience for such contexts, especially in the case of percentage option rules (which are based on user id by default). I suggest some constant string like `"<n/a>"` for such cases.
* An "end-to-end" test case that tests the provider in a "real life" situation (i.e. using the provider via `SetProviderAsync`) and exercises all of its parts (evaluation with context, user attribute translation, user object building, etc).
* Upgrade to the latest ConfigCat SDK version (this is necessary for the new test case).
* Corrections to README.md, especially to code samples which seem to be outdated or even contain syntax errors.
