### PR TITLE
build: Cleanup sdk version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,48 +2,45 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths-ignore:
-    - '**.md'
+      - "**.md"
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths-ignore:
-    - '**.md'
+      - "**.md"
 
 jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        submodules: recursive
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
 
-    - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v4
-      env:
-        NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        dotnet-version: |
-          6.0.x
-          7.0.x
-          8.0.x
-        source-url: https://nuget.pkg.github.com/open-feature/index.json
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        env:
+          NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          global-json-file: global.json
+          source-url: https://nuget.pkg.github.com/open-feature/index.json
 
-    - name: Restore
-      run: dotnet restore
+      - name: Restore
+        run: dotnet restore
 
-    - name: Build
-      run: dotnet build --no-restore
+      - name: Build
+        run: dotnet build --no-restore
 
-    - name: Test
-      run: dotnet test --no-build --logger GitHubActions
+      - name: Test
+        run: dotnet test --no-build --logger GitHubActions
 
   e2e:
     runs-on: ubuntu-latest
@@ -59,25 +56,22 @@ jobs:
         ports:
           - 9090:9090
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        submodules: recursive
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
 
-    - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v4
-      env:
-        NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        dotnet-version: |
-          6.0.x
-          7.0.x
-          8.0.x
-        source-url: https://nuget.pkg.github.com/open-feature/index.json
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        env:
+          NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          global-json-file: global.json
+          source-url: https://nuget.pkg.github.com/open-feature/index.json
 
-    - name: Test
-      run: dotnet build && E2E=true dotnet test --logger GitHubActions
+      - name: Test
+        run: dotnet build && E2E=true dotnet test --logger GitHubActions
 
   packaging:
     needs: build
@@ -89,41 +83,38 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        submodules: recursive
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
 
-    - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v4
-      env:
-        NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        dotnet-version: |
-          6.0.x
-          7.0.x
-          8.0.x
-        source-url: https://nuget.pkg.github.com/open-feature/index.json
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        env:
+          NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          global-json-file: global.json
+          source-url: https://nuget.pkg.github.com/open-feature/index.json
 
-    - name: Restore
-      run: dotnet restore
+      - name: Restore
+        run: dotnet restore
 
-    - name: Pack NuGet packages (CI versions)
-      if: startsWith(github.ref, 'refs/heads/')
-      run: dotnet pack --no-restore --version-suffix "ci.$(date -u +%Y%m%dT%H%M%S)+sha.${GITHUB_SHA:0:9}"
+      - name: Pack NuGet packages (CI versions)
+        if: startsWith(github.ref, 'refs/heads/')
+        run: dotnet pack --no-restore --version-suffix "ci.$(date -u +%Y%m%dT%H%M%S)+sha.${GITHUB_SHA:0:9}"
 
-    - name: Pack NuGet packages (PR versions)
-      if: startsWith(github.ref, 'refs/pull/')
-      run: dotnet pack --no-restore --version-suffix "pr.$(date -u +%Y%m%dT%H%M%S)+sha.${GITHUB_SHA:0:9}"
+      - name: Pack NuGet packages (PR versions)
+        if: startsWith(github.ref, 'refs/pull/')
+        run: dotnet pack --no-restore --version-suffix "pr.$(date -u +%Y%m%dT%H%M%S)+sha.${GITHUB_SHA:0:9}"
 
-    - name: Publish NuGet packages (base)
-      if: github.event.pull_request.head.repo.fork == false
-      run: dotnet nuget push "src/**/*.nupkg" --api-key "${{ secrets.GITHUB_TOKEN }}" --source https://nuget.pkg.github.com/open-feature/index.json
+      - name: Publish NuGet packages (base)
+        if: github.event.pull_request.head.repo.fork == false
+        run: dotnet nuget push "src/**/*.nupkg" --api-key "${{ secrets.GITHUB_TOKEN }}" --source https://nuget.pkg.github.com/open-feature/index.json
 
-    - name: Publish NuGet packages (fork)
-      if: github.event.pull_request.head.repo.fork == true
-      uses: actions/upload-artifact@v4.3.6
-      with:
-        name: nupkgs
-        path: src/**/*.nupkg
+      - name: Publish NuGet packages (fork)
+        if: github.event.pull_request.head.repo.fork == true
+        uses: actions/upload-artifact@v4.3.6
+        with:
+          name: nupkgs
+          path: src/**/*.nupkg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
           command: manifest
           token: ${{secrets.GITHUB_TOKEN}}
           default-branch: main
+          release-type: simple
 
       - uses: actions/checkout@v4
         if: ${{ steps.release.outputs.releases_created }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,7 @@ jobs:
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          dotnet-version: |
-            6.0.x
-            7.0.x
-            8.0.x
+          global-json-file: global.json
           source-url: https://nuget.pkg.github.com/open-feature/index.json
 
       - name: Install dependencies
@@ -45,7 +42,7 @@ jobs:
 
       - name: Pack
         if: ${{ steps.release.outputs.releases_created }}
-        run:  |
+        run: |
           dotnet pack --configuration Release --no-build
 
       - name: Publish to Nuget

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net462;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net462;net8.0</TargetFrameworks>
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/open-feature/dotnet-sdk-contrib</RepositoryUrl>
         <Description>OpenFeature is an open specification that provides a vendor-agnostic,

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -1,28 +1,30 @@
 <Project>
-  <Import Project=".\Common.props" />
+    <Import Project=".\Common.props" />
 
-  <PropertyGroup>
-    <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
-    <Deterministic Condition="'$(CI)' == 'true'">true</Deterministic>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackRelease>true</PackRelease>
-  </PropertyGroup>
+    <PropertyGroup>
+        <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
+        <Deterministic Condition="'$(CI)' == 'true'">true</Deterministic>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <PackRelease>true</PackRelease>
+    </PropertyGroup>
 
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net462;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/open-feature/dotnet-sdk-contrib</RepositoryUrl>
-    <Description>OpenFeature is an open specification that provides a vendor-agnostic, community-driven API for feature flagging that works with your favorite feature flag management tool or in-house solution.</Description>
-    <PackageTags>Feature;OpenFeature;Flags;</PackageTags>
-    <PackageIcon>openfeature-icon.png</PackageIcon>
-    <PackageProjectUrl>https://openfeature.dev</PackageProjectUrl>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <Authors>OpenFeature Authors</Authors>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFrameworks>netstandard2.0;net462;net8.0;net9.0</TargetFrameworks>
+        <RepositoryType>git</RepositoryType>
+        <RepositoryUrl>https://github.com/open-feature/dotnet-sdk-contrib</RepositoryUrl>
+        <Description>OpenFeature is an open specification that provides a vendor-agnostic,
+            community-driven API for feature flagging that works with your favorite feature flag
+            management tool or in-house solution.</Description>
+        <PackageTags>Feature;OpenFeature;Flags;</PackageTags>
+        <PackageIcon>openfeature-icon.png</PackageIcon>
+        <PackageProjectUrl>https://openfeature.dev</PackageProjectUrl>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+        <Authors>OpenFeature Authors</Authors>
+        <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)openfeature-icon.png" Pack="true" PackagePath="\" />
-  </ItemGroup>
+    <ItemGroup>
+        <None Include="$(MSBuildThisFileDirectory)openfeature-icon.png" Pack="true" PackagePath="\" />
+    </ItemGroup>
 
 </Project>

--- a/build/Common.props
+++ b/build/Common.props
@@ -1,33 +1,34 @@
 <Project>
 
-  <ItemGroup>
-    <PackageReference Include="OpenFeature" Version="$(OpenFeatureVer)" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="OpenFeature" Version="$(OpenFeatureVer)" />
+    </ItemGroup>
 
-  <PropertyGroup>
-    <LangVersion>7.3</LangVersion>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-  </PropertyGroup>
+    <PropertyGroup>
+        <LangVersion>latest</LangVersion>
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+        <DebugType>full</DebugType>
+        <DebugSymbols>true</DebugSymbols>
+    </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)'=='Release'">
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-  </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)'=='Release'">
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup>
 
-  <PropertyGroup Label="Package versions used in this repository">
-    <!--
+    <PropertyGroup Label="Package versions used in this repository">
+        <!--
       Please sort alphabetically.
       Refer to https://docs.microsoft.com/nuget/concepts/package-versioning for semver syntax.
     -->
-    <!-- 2.0-2.9999 -->
-    <OpenFeatureVer>[2.0,3.0)</OpenFeatureVer>
-  </PropertyGroup>
+        <!-- 2.0-2.9999 -->
+        <OpenFeatureVer>[2.0,3.0)</OpenFeatureVer>
+    </PropertyGroup>
 
-  <ItemGroup Condition="'$(OS)' == 'Unix'">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
-  </ItemGroup>
+    <ItemGroup Condition="'$(OS)' == 'Unix'">
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3"
+            PrivateAssets="all" />
+    </ItemGroup>
 </Project>

--- a/build/Common.tests.props
+++ b/build/Common.tests.props
@@ -3,7 +3,7 @@
 
     <PropertyGroup>
         <IsPackable>false</IsPackable>
-        <TargetFrameworks>net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     </PropertyGroup>
 

--- a/build/Common.tests.props
+++ b/build/Common.tests.props
@@ -1,55 +1,57 @@
 <Project>
-  <Import Project=".\Common.props" />
+    <Import Project=".\Common.props" />
 
-  <PropertyGroup>
-    <IsPackable>false</IsPackable>
-    <TargetFrameworks>net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
-  </PropertyGroup>
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+        <TargetFrameworks>net9.0</TargetFrameworks>
+        <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
+    </PropertyGroup>
 
-  <PropertyGroup Condition="$(MSBuildProjectName.EndsWith('.Test'))">
-    <IsTestProject>true</IsTestProject>
-  </PropertyGroup>
+    <PropertyGroup Condition="$(MSBuildProjectName.EndsWith('.Test'))">
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
 
-  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
-    <Content Include="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'DotnetSdkContrib.sln'))\build\xunit.runner.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+    <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
+        <Content
+            Include="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'DotnetSdkContrib.sln'))\build\xunit.runner.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="$(AutoFixtureVer)" />
-    <PackageReference Include="coverlet.collector" Version="$(CoverletCollectorVer)">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="$(CoverletCollectorVer)">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVer)" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="$(GitHubActionsTestLoggerVer)" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
-    <PackageReference Include="NSubstitute" Version="$(NSubstituteVer)" />
-    <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioPkgVer)">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="AutoFixture" Version="$(AutoFixtureVer)" />
+        <PackageReference Include="coverlet.collector" Version="$(CoverletCollectorVer)">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.msbuild" Version="$(CoverletCollectorVer)">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVer)" />
+        <PackageReference Include="GitHubActionsTestLogger" Version="$(GitHubActionsTestLoggerVer)" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
+        <PackageReference Include="NSubstitute" Version="$(NSubstituteVer)" />
+        <PackageReference Include="xunit" Version="$(XUnitPkgVer)" />
+        <PackageReference Include="xunit.runner.visualstudio"
+            Version="$(XUnitRunnerVisualStudioPkgVer)">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
 
-  <PropertyGroup Label="Package versions used in this repository">
-    <!--
+    <PropertyGroup Label="Package versions used in this repository">
+        <!--
       Please sort alphabetically.
       Refer to https://docs.microsoft.com/nuget/concepts/package-versioning for semver syntax.
     -->
-    <AutoFixtureVer>[4.17.0]</AutoFixtureVer>
-    <CoverletCollectorVer>[3.1.2]</CoverletCollectorVer>
-    <FluentAssertionsVer>[6.7.0]</FluentAssertionsVer>
-    <GitHubActionsTestLoggerVer>[2.3.3]</GitHubActionsTestLoggerVer>
-    <MicrosoftNETTestSdkPkgVer>[17.3.2]</MicrosoftNETTestSdkPkgVer>
-    <NSubstituteVer>[5.0.0]</NSubstituteVer>
-    <XUnitRunnerVisualStudioPkgVer>[2.4.3,3.0)</XUnitRunnerVisualStudioPkgVer>
-    <XUnitPkgVer>[2.4.1,3.0)</XUnitPkgVer>
-  </PropertyGroup>
+        <AutoFixtureVer>[4.17.0]</AutoFixtureVer>
+        <CoverletCollectorVer>[3.1.2]</CoverletCollectorVer>
+        <FluentAssertionsVer>[6.7.0]</FluentAssertionsVer>
+        <GitHubActionsTestLoggerVer>[2.3.3]</GitHubActionsTestLoggerVer>
+        <MicrosoftNETTestSdkPkgVer>[17.3.2]</MicrosoftNETTestSdkPkgVer>
+        <NSubstituteVer>[5.0.0]</NSubstituteVer>
+        <XUnitRunnerVisualStudioPkgVer>[2.4.3,3.0)</XUnitRunnerVisualStudioPkgVer>
+        <XUnitPkgVer>[2.4.1,3.0)</XUnitPkgVer>
+    </PropertyGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
-  "sdk": {
-    "rollForward": "latestFeature",
-    "version": "8.0.403"
-  }
+    "sdk": {
+        "rollForward": "latestFeature",
+        "version": "9.0.202",
+        "allowPrerelease": false
+    }
 }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
     "sdk": {
         "rollForward": "latestFeature",
-        "version": "9.0.202",
+        "version": "8.0.407",
         "allowPrerelease": false
     }
 }

--- a/src/OpenFeature.Contrib.Providers.Flipt/OpenFeature.Contrib.Providers.Flipt.csproj
+++ b/src/OpenFeature.Contrib.Providers.Flipt/OpenFeature.Contrib.Providers.Flipt.csproj
@@ -17,18 +17,20 @@
         </AssemblyAttribute>
     </ItemGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0'">
-        <PackageReference Include="System.Net.Http" Version="4.3.4"/>
+    <ItemGroup
+        Condition=" '$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0'">
+        <PackageReference Include="System.Net.Http" Version="4.3.4" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="NSwag.MSBuild" Version="14.1.0">
+        <PackageReference Include="NSwag.MSBuild" Version="14.3.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0"/>
-        <Compile Include="$(ProjectDir)obj/$(ConfigurationName)/$(TargetFramework)/Flipt.Rest.Client.cs"/>
-        <PackageReference Include="System.Text.Json" Version="8.0.5"/>
+        <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+        <Compile
+            Include="$(ProjectDir)obj/$(ConfigurationName)/$(TargetFramework)/Flipt.Rest.Client.cs" />
+        <PackageReference Include="System.Text.Json" Version="8.0.5" />
     </ItemGroup>
 
     <PropertyGroup>
@@ -36,6 +38,7 @@
     </PropertyGroup>
 
     <Target Name="NSwag" BeforeTargets="BeforeBuild">
-        <Exec Command="$(NSwagExe_Net80) openapi2csclient /className:FliptRestClient /namespace:Flipt.Rest /input:&quot;openapi.yaml&quot; /output:&quot;$(ProjectDir)obj/$(ConfigurationName)/$(TargetFramework)/Flipt.Rest.Client.cs&quot; /GenerateExceptionClasses:true /OperationGenerationMode:SingleClientFromPathSegments /JsonLibrary:SystemTextJson /GenerateOptionalParameters:true /GenerateDefaultValues:true /GenerateResponseClasses:true /GenerateClientInterfaces:true /GenerateClientClasses:true /GenerateDtoTypes:true /ExceptionClass:FliptRestException /GenerateNativeRecords:true /UseBaseUrl:false /GenerateBaseUrlProperty:false"/>
+        <Exec
+            Command="$(NSwagExe_Net80) openapi2csclient /className:FliptRestClient /namespace:Flipt.Rest /input:&quot;openapi.yaml&quot; /output:&quot;$(ProjectDir)obj/$(ConfigurationName)/$(TargetFramework)/Flipt.Rest.Client.cs&quot; /GenerateExceptionClasses:true /OperationGenerationMode:SingleClientFromPathSegments /JsonLibrary:SystemTextJson /GenerateOptionalParameters:true /GenerateDefaultValues:true /GenerateResponseClasses:true /GenerateClientInterfaces:true /GenerateClientClasses:true /GenerateDtoTypes:true /ExceptionClass:FliptRestException /GenerateNativeRecords:true /UseBaseUrl:false /GenerateBaseUrlProperty:false" />
     </Target>
 </Project>


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request includes several configuration and project files updates to streamline the build process and update dependencies. The most important changes include updating the .NET versions, modifying target frameworks, and improving the formatting of configuration files.

### Updates to .NET Versions and Target Frameworks:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL33-R33): Replaced multiple `dotnet-version` lines with a single `global-json-file` reference to `global.json` for consistency. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL33-R33) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL73-R70) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL103-R97)
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L31-R31): Updated to use `global-json-file` instead of specifying multiple `dotnet-version` lines.
* [`build/Common.prod.props`](diffhunk://#diff-c123fcece83dd5f1a59e23928148519fe1d6515f9c14f1337c7a6878a2720911L12-R17): Removed older target frameworks and kept only `netstandard2.0`, `net462`, and `net8.0`.
* [`build/Common.tests.props`](diffhunk://#diff-5472aa271be4e6ac0c793a3c1b9226e4f9a7907a6baa99ea16542fb89107ae86L6-R6): Updated the target framework to `net8.0` and adjusted the condition for Windows-specific frameworks. [[1]](diffhunk://#diff-5472aa271be4e6ac0c793a3c1b9226e4f9a7907a6baa99ea16542fb89107ae86L6-R6) [[2]](diffhunk://#diff-5472aa271be4e6ac0c793a3c1b9226e4f9a7907a6baa99ea16542fb89107ae86L15-R16)

### Dependency and Configuration Updates:

* [`global.json`](diffhunk://#diff-8df3cd354bc584349d04ad5675b33c042d8b99b741b8b95af394c55e0f5001bfL4-R5): Updated the .NET SDK version to `8.0.407` and set `allowPrerelease` to `false`.
* [`build/Common.props`](diffhunk://#diff-3e9cdf5c2ef721be7342fcd07bd9e3567805d13357c97221e15137225f64e063L8-R8): Changed `LangVersion` to `latest` and adjusted formatting for package references. [[1]](diffhunk://#diff-3e9cdf5c2ef721be7342fcd07bd9e3567805d13357c97221e15137225f64e063L8-R8) [[2]](diffhunk://#diff-3e9cdf5c2ef721be7342fcd07bd9e3567805d13357c97221e15137225f64e063L31-R32)
* [`src/OpenFeature.Contrib.Providers.Flipt/OpenFeature.Contrib.Providers.Flipt.csproj`](diffhunk://#diff-8614baa01054f80d2cf9e7b8961e7af91cf92d0396796e931393a1690d9035b1L20-R32): Updated `NSwag.MSBuild` package version and improved formatting for item groups and commands. [[1]](diffhunk://#diff-8614baa01054f80d2cf9e7b8961e7af91cf92d0396796e931393a1690d9035b1L20-R32) [[2]](diffhunk://#diff-8614baa01054f80d2cf9e7b8961e7af91cf92d0396796e931393a1690d9035b1L39-R42)

### Formatting Improvements:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL7-R11): Corrected indentation for `paths-ignore` under `push` and `pull_request`.
* [`build/Common.prod.props`](diffhunk://#diff-c123fcece83dd5f1a59e23928148519fe1d6515f9c14f1337c7a6878a2720911L12-R17): Improved formatting for `Description` and other properties.
* [`build/Common.tests.props`](diffhunk://#diff-5472aa271be4e6ac0c793a3c1b9226e4f9a7907a6baa99ea16542fb89107ae86L35-R37): Adjusted formatting for package references and content inclusion.

### Notes
- There is a lot of whitespace cleanup.
- I tried to bump to SDK v9, but Flipt uses a package that is incompatible with that version. I need to revisit it later.