### PR TITLE
chore: update Renovate configuration to extend community tooling

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,6 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ],
-  "semanticCommits": "enabled",
-  "labels": [
-    "renovate"
-  ]
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "github>open-feature/community-tooling"
+    ]
 }


### PR DESCRIPTION
Signed-off-by: André Silva <2493377+askpt@users.noreply.github.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request includes a modification to the `renovate.json` file to update the configuration for dependency management. The change specifically updates the `extends` field and removes some configurations.

Configuration updates:

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L4-R4): Updated the `extends` field to use `github>open-feature/community-tooling` and removed the `semanticCommits` and `labels` configurations.

### Notes
<!-- any additional notes for this PR -->
Check https://github.com/open-feature/dotnet-sdk/pull/364