### PR TITLE
ci: Ensure conditional check for .NET SDK setup in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
+        if: ${{ steps.release.outputs.releases_created }}
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Signed-off-by: André Silva <2493377+askpt@users.noreply.github.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->
This pull request includes a minor change to the `.github/workflows/release.yml` file. The change adds a condition to the `.NET SDK` setup step to only run if releases are created.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R29): Added a condition to the `.NET SDK` setup step to run only if `steps.release.outputs.releases_created` is true.