### PR TITLE
test: Remove FluentAssertions

### DIFF
--- a/build/Common.tests.props
+++ b/build/Common.tests.props
@@ -28,7 +28,6 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVer)" />
         <PackageReference Include="GitHubActionsTestLogger" Version="$(GitHubActionsTestLoggerVer)" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
         <PackageReference Include="NSubstitute" Version="$(NSubstituteVer)" />
@@ -47,7 +46,6 @@
     -->
         <AutoFixtureVer>[4.17.0]</AutoFixtureVer>
         <CoverletCollectorVer>[3.1.2]</CoverletCollectorVer>
-        <FluentAssertionsVer>[6.7.0]</FluentAssertionsVer>
         <GitHubActionsTestLoggerVer>[2.3.3]</GitHubActionsTestLoggerVer>
         <MicrosoftNETTestSdkPkgVer>[17.3.2]</MicrosoftNETTestSdkPkgVer>
         <NSubstituteVer>[5.0.0]</NSubstituteVer>

--- a/test/OpenFeature.Contrib.Providers.Flipt.Test/FlipExtensionsTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flipt.Test/FlipExtensionsTest.cs
@@ -1,21 +1,28 @@
-using System.Text.Json;
-using FluentAssertions;
 using OpenFeature.Contrib.Providers.Flipt.Converters;
 using OpenFeature.Model;
+using System.Text.Json;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenFeature.Contrib.Providers.Flipt.Test;
 
 public class FlipExtensionsTest
 {
+    private readonly ITestOutputHelper _output;
+
+    public FlipExtensionsTest(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
     [Fact]
     public void ToStringDictionary_WithEmptyContext_ShouldReturnEmptyDictionary()
     {
         var evaluationContext = EvaluationContext.Builder().Build();
         var result = evaluationContext.ToStringDictionary();
 
-        result.Should().NotBeNull();
-        result.Should().BeEmpty();
+        Assert.NotNull(result);
+        Assert.Empty(result);
     }
 
     [Fact]
@@ -27,9 +34,9 @@ public class FlipExtensionsTest
             .Build();
         var result = evaluationContext.ToStringDictionary();
 
-        result.Should().NotBeNull();
-        result.Should().NotBeEmpty();
-        result.Keys.Should().Contain("location");
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+        Assert.Contains("location", result.Keys);
     }
 
     [Fact]
@@ -41,10 +48,12 @@ public class FlipExtensionsTest
             .Build();
         var result = evaluationContext.ToStringDictionary();
 
-        result.Should().NotBeNull();
-        result.Should().NotBeEmpty();
-        result.Keys.Should().Contain("age");
-        result["age"].Should().Be("23");
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+        Assert.Contains("age", result.Keys);
+
+        var actual = result["age"];
+        Assert.Equal("23", actual);
     }
 
     [Fact]
@@ -62,14 +71,13 @@ public class FlipExtensionsTest
             .Build();
         var result = evaluationContext.ToStringDictionary();
 
-        result.Should().NotBeNull();
-        result.Should().NotBeEmpty();
-        result.Keys.Should().Contain("config");
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+        Assert.Contains("config", result.Keys);
 
-        JsonSerializer
-            .Deserialize<Structure>(result["config"],
-                JsonConverterExtensions.DefaultSerializerSettings).Should()
-            .BeEquivalentTo(testStructure);
+        var expected = JsonSerializer.Serialize(testStructure, JsonConverterExtensions.DefaultSerializerSettings);
+        var actual = result["config"];
+        Assert.Equal(expected, actual);
     }
 
     [Fact]
@@ -88,13 +96,13 @@ public class FlipExtensionsTest
             .Build();
         var result = evaluationContext.ToStringDictionary();
 
-        result.Should().NotBeNull();
-        result.Should().NotBeEmpty();
-        result.Keys.Should().Contain("config");
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+        Assert.Contains("config", result.Keys);
 
-        var deserialized = JsonSerializer.Deserialize<Structure>(result["config"],
-            JsonConverterExtensions.DefaultSerializerSettings);
-        deserialized.Should().BeEquivalentTo(testStructure);
+        var expected = JsonSerializer.Serialize(testStructure, JsonConverterExtensions.DefaultSerializerSettings);
+        var actual = result["config"];
+        Assert.Equal(expected, actual);
     }
 
     [Fact]
@@ -115,13 +123,13 @@ public class FlipExtensionsTest
             .Build();
         var result = evaluationContext.ToStringDictionary();
 
-        result.Should().NotBeNull();
-        result.Should().NotBeEmpty();
-        result.Keys.Should().Contain("config");
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+        Assert.Contains("config", result.Keys);
 
-        var deserialized = JsonSerializer.Deserialize<Structure>(result["config"],
-            JsonConverterExtensions.DefaultSerializerSettings);
-        deserialized.Should().BeEquivalentTo(testStructure);
+        var expected = JsonSerializer.Serialize(testStructure, JsonConverterExtensions.DefaultSerializerSettings);
+        var actual = result["config"];
+        Assert.Equal(expected, actual);
     }
 
     [Fact]
@@ -144,12 +152,12 @@ public class FlipExtensionsTest
             .Build();
         var result = evaluationContext.ToStringDictionary();
 
-        result.Should().NotBeNull();
-        result.Should().NotBeEmpty();
-        result.Keys.Should().Contain("config");
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+        Assert.Contains("config", result.Keys);
 
-        var deserialized = JsonSerializer.Deserialize<Structure>(result["config"],
-            JsonConverterExtensions.DefaultSerializerSettings);
-        deserialized.Should().BeEquivalentTo(testStructure);
+        var expected = JsonSerializer.Serialize(testStructure, JsonConverterExtensions.DefaultSerializerSettings);
+        var actual = result["config"];
+        Assert.Equal(expected, actual);
     }
 }

--- a/test/OpenFeature.Contrib.Providers.Flipt.Test/FliptExtensionsTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flipt.Test/FliptExtensionsTest.cs
@@ -6,11 +6,11 @@ using Xunit.Abstractions;
 
 namespace OpenFeature.Contrib.Providers.Flipt.Test;
 
-public class FlipExtensionsTest
+public class FliptExtensionsTest
 {
     private readonly ITestOutputHelper _output;
 
-    public FlipExtensionsTest(ITestOutputHelper output)
+    public FliptExtensionsTest(ITestOutputHelper output)
     {
         _output = output;
     }

--- a/test/OpenFeature.Contrib.Providers.Flipt.Test/FliptExtensionsTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flipt.Test/FliptExtensionsTest.cs
@@ -2,19 +2,11 @@ using OpenFeature.Contrib.Providers.Flipt.Converters;
 using OpenFeature.Model;
 using System.Text.Json;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace OpenFeature.Contrib.Providers.Flipt.Test;
 
 public class FliptExtensionsTest
 {
-    private readonly ITestOutputHelper _output;
-
-    public FliptExtensionsTest(ITestOutputHelper output)
-    {
-        _output = output;
-    }
-
     [Fact]
     public void ToStringDictionary_WithEmptyContext_ShouldReturnEmptyDictionary()
     {

--- a/test/OpenFeature.Contrib.Providers.Flipt.Test/FliptExtensionsTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flipt.Test/FliptExtensionsTest.cs
@@ -102,7 +102,8 @@ public class FliptExtensionsTest
     {
         var sampleDictionary = new Dictionary<string, Value>();
         sampleDictionary["config2"] = new Value([
-            new Value([new Value("element1-1"), new Value("element1-2")]), new Value("element2"),
+            new Value([new Value("element1-1"), new Value("element1-2")]),
+            new Value("element2"),
             new Value("element3")
         ]);
         sampleDictionary["config3"] = new Value(DateTime.Now);

--- a/test/OpenFeature.Contrib.Providers.Flipt.Test/FliptProviderTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flipt.Test/FliptProviderTest.cs
@@ -1,5 +1,4 @@
 using Flipt.Rest;
-using FluentAssertions;
 using Moq;
 using OpenFeature.Contrib.Providers.Flipt.ClientWrapper;
 using OpenFeature.Error;
@@ -23,10 +22,8 @@ public class FliptProviderTest
     [Fact]
     public void CreateFliptProvider_GivenEmptyUrl_ShouldThrowInvalidOperationException()
     {
-        var act = void() => new FliptProvider("");
-        act.Should().Throw<UriFormatException>();
+        Assert.Throws<UriFormatException>(() => new FliptProvider(""));
     }
-
 
     [Fact]
     public async Task
@@ -49,9 +46,7 @@ public class FliptProviderTest
 
         var provider = new FliptProvider(new FliptToOpenFeatureConverter(mockFliptClientWrapper.Object));
 
-        var resolution = async Task<ResolutionDetails<double>>() =>
-            await provider.ResolveDoubleValueAsync(flagKey, 0.0);
-        await resolution.Should().ThrowAsync<TypeMismatchException>();
+        await Assert.ThrowsAsync<TypeMismatchException>(async () => await provider.ResolveDoubleValueAsync(flagKey, 0.0));
     }
 
     [Fact]

--- a/test/OpenFeature.Contrib.Providers.Flipt.Test/FliptToOpenFeatureConverterTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flipt.Test/FliptToOpenFeatureConverterTest.cs
@@ -1,13 +1,14 @@
 // ReSharper disable RedundantUsingDirective
 
-using System.Net;
-using System.Net.Http;
 using Flipt.Rest;
-using FluentAssertions;
 using Moq;
 using OpenFeature.Constant;
 using OpenFeature.Contrib.Providers.Flipt.ClientWrapper;
+using OpenFeature.Contrib.Providers.Flipt.Converters;
 using OpenFeature.Model;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
 using Xunit;
 
 namespace OpenFeature.Contrib.Providers.Flipt.Test;
@@ -30,10 +31,8 @@ public class FliptToOpenFeatureConverterTest
             .ThrowsAsync(new FliptRestException("", (int)thrownStatusCode, "", null, null));
 
         var fliptToOpenFeature = new FliptToOpenFeatureConverter(mockFliptClientWrapper.Object);
-        var resolution = async Task<ResolutionDetails<bool>>() =>
-            await fliptToOpenFeature.EvaluateBooleanAsync("flagKey", fallbackValue);
 
-        await resolution.Should().ThrowAsync<HttpRequestException>();
+        await Assert.ThrowsAsync<HttpRequestException>(async () => await fliptToOpenFeature.EvaluateBooleanAsync("flagKey", fallbackValue));
     }
 
     [Theory]
@@ -54,9 +53,9 @@ public class FliptToOpenFeatureConverterTest
         var fliptToOpenFeature = new FliptToOpenFeatureConverter(mockFliptClientWrapper.Object);
         var resolution = await fliptToOpenFeature.EvaluateBooleanAsync("show-feature", false);
 
-        resolution.FlagKey.Should().Be(flagKey);
-        resolution.Value.Should().Be(valueFromSrc);
-        resolution.Reason.Should().Be(Reason.TargetingMatch);
+        Assert.Equal(flagKey, resolution.FlagKey);
+        Assert.Equal(valueFromSrc, resolution.Value);
+        Assert.Equal(Reason.TargetingMatch, resolution.Reason);
     }
 
     [Theory]
@@ -70,10 +69,8 @@ public class FliptToOpenFeatureConverterTest
             .ThrowsAsync(new FliptRestException("", (int)HttpStatusCode.NotFound, "", null, null));
 
         var fliptToOpenFeature = new FliptToOpenFeatureConverter(mockFliptClientWrapper.Object);
-        var resolution = async Task<ResolutionDetails<bool>>() =>
-            await fliptToOpenFeature.EvaluateBooleanAsync(flagKey, fallBackValue);
 
-        await resolution.Should().ThrowAsync<HttpRequestException>();
+        await Assert.ThrowsAsync<HttpRequestException>(async () => await fliptToOpenFeature.EvaluateBooleanAsync(flagKey, fallBackValue));
     }
 
     // EvaluateAsync Tests
@@ -93,10 +90,8 @@ public class FliptToOpenFeatureConverterTest
             .ThrowsAsync(new FliptRestException("", (int)thrownStatusCode, "", null, null));
 
         var fliptToOpenFeature = new FliptToOpenFeatureConverter(mockFliptClientWrapper.Object);
-        var resolution = async Task<ResolutionDetails<double>>() =>
-            await fliptToOpenFeature.EvaluateAsync("flagKey", fallbackValue);
-
-        await resolution.Should().ThrowAsync<HttpRequestException>();
+        
+        await Assert.ThrowsAsync<HttpRequestException>(async () => await fliptToOpenFeature.EvaluateAsync("flagKey", fallbackValue));
     }
 
     [Theory]
@@ -122,10 +117,10 @@ public class FliptToOpenFeatureConverterTest
         var fliptToOpenFeature = new FliptToOpenFeatureConverter(mockFliptClientWrapper.Object);
         var resolution = await fliptToOpenFeature.EvaluateAsync(flagKey, valueFromSrc);
 
-        resolution.FlagKey.Should().Be(flagKey);
-        resolution.Variant.Should().Be(valueFromSrc.ToString() ?? string.Empty);
-        resolution.Value.Should().BeEquivalentTo(expectedValue?.ToString());
-        resolution.Reason.Should().Be(Reason.TargetingMatch);
+        Assert.Equal(flagKey, resolution.FlagKey);
+        Assert.Equal(valueFromSrc.ToString() ?? string.Empty, resolution.Value);
+        Assert.Equal(expectedValue?.ToString(), resolution.Value);
+        Assert.Equal(Reason.TargetingMatch, resolution.Reason);
     }
 
     [Fact]
@@ -160,11 +155,13 @@ public class FliptToOpenFeatureConverterTest
         var fliptToOpenFeature = new FliptToOpenFeatureConverter(mockFliptClientWrapper.Object);
         var resolution = await fliptToOpenFeature.EvaluateAsync(flagKey, new Value());
 
-        resolution.FlagKey.Should().Be(flagKey);
-        resolution.Variant.Should().Be(variantKey);
-        resolution.Value.Should().BeEquivalentTo(expectedValue);
-    }
+        Assert.Equal(flagKey, resolution.FlagKey);
+        Assert.Equal(variantKey, resolution.Variant);
 
+        var expected = JsonSerializer.Serialize(expectedValue, JsonConverterExtensions.DefaultSerializerSettings);
+        var actual = JsonSerializer.Serialize(resolution.Value, JsonConverterExtensions.DefaultSerializerSettings);
+        Assert.Equal(expected, actual);
+    }
 
     [Fact]
     public async Task
@@ -179,12 +176,9 @@ public class FliptToOpenFeatureConverterTest
             .ThrowsAsync(new FliptRestException("", (int)HttpStatusCode.NotFound, "", null, null));
 
         var fliptToOpenFeature = new FliptToOpenFeatureConverter(mockFliptClientWrapper.Object);
-        var resolution = async Task<ResolutionDetails<Value>>() =>
-            await fliptToOpenFeature.EvaluateAsync("non-existent-flag", fallbackValue);
-
-        await resolution.Should().ThrowAsync<HttpRequestException>();
+        
+        await Assert.ThrowsAsync<HttpRequestException>(async () => await fliptToOpenFeature.EvaluateAsync("non-existent-flag", fallbackValue));
     }
-
 
     [Fact]
     public async Task
@@ -196,9 +190,7 @@ public class FliptToOpenFeatureConverterTest
             .ThrowsAsync(new FliptRestException("", (int)HttpStatusCode.NotFound, "", null, null));
 
         var fliptToOpenFeature = new FliptToOpenFeatureConverter(mockFliptClientWrapper.Object);
-        var resolution = async Task<ResolutionDetails<Value>>() =>
-            await fliptToOpenFeature.EvaluateAsync("non-existent-flag", fallbackValue);
 
-        await resolution.Should().ThrowAsync<HttpRequestException>();
+        await Assert.ThrowsAsync<HttpRequestException>(async () => await fliptToOpenFeature.EvaluateAsync("non-existent-flag", fallbackValue));
     }
 }

--- a/test/OpenFeature.Contrib.Providers.Flipt.Test/FliptToOpenFeatureConverterTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flipt.Test/FliptToOpenFeatureConverterTest.cs
@@ -90,7 +90,7 @@ public class FliptToOpenFeatureConverterTest
             .ThrowsAsync(new FliptRestException("", (int)thrownStatusCode, "", null, null));
 
         var fliptToOpenFeature = new FliptToOpenFeatureConverter(mockFliptClientWrapper.Object);
-        
+
         await Assert.ThrowsAsync<HttpRequestException>(async () => await fliptToOpenFeature.EvaluateAsync("flagKey", fallbackValue));
     }
 
@@ -176,7 +176,7 @@ public class FliptToOpenFeatureConverterTest
             .ThrowsAsync(new FliptRestException("", (int)HttpStatusCode.NotFound, "", null, null));
 
         var fliptToOpenFeature = new FliptToOpenFeatureConverter(mockFliptClientWrapper.Object);
-        
+
         await Assert.ThrowsAsync<HttpRequestException>(async () => await fliptToOpenFeature.EvaluateAsync("non-existent-flag", fallbackValue));
     }
 

--- a/test/OpenFeature.Contrib.Providers.Flipt.Test/OpenFeature.Contrib.Providers.Flipt.Test.csproj
+++ b/test/OpenFeature.Contrib.Providers.Flipt.Test/OpenFeature.Contrib.Providers.Flipt.Test.csproj
@@ -15,7 +15,6 @@
 
     <ItemGroup>
         <PackageReference Include="Moq" Version="4.20.72"/>
-        <PackageReference Update="FluentAssertions" Version="6.12.1"/>
         <ProjectReference Include="..\..\src\OpenFeature.Contrib.Providers.Flipt\OpenFeature.Contrib.Providers.Flipt.csproj"/>
     </ItemGroup>
 


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- Removes FluentAssertions from dotnet-sdk-contrib repository

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #326

### Notes
<!-- any additional notes for this PR -->

Looks like only the Flipt tests were referencing this so it was relatively straight forward. In some of the tests in the `FlipExtensionTests.cs` file I compare the Value/Structure classes via JSON. I looked at building some kind of Equality comparer but I think this approach might over complicate the solution. I've stuck with using the Xunit base assertions, we could opt to use something like shoudly in the future if readability is a concern.

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

