### PR TITLE
ci: Fix CI permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      packages: read
 
     steps:
       - name: Checkout
@@ -51,6 +52,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      packages: read
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    permissions:
+      contents: read
+      pull-requests: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -44,6 +48,9 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,4 +1,4 @@
-name: 'Lint PR'
+name: "Lint PR"
 
 on:
   pull_request_target:
@@ -10,6 +10,9 @@ on:
 jobs:
   main:
     name: Validate PR title
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5
@@ -24,16 +27,16 @@ jobs:
           header: pr-title-lint-error
           message: |
             Hey there and thank you for opening this pull request! 👋🏼
-            
+
             We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
             Details:
-            
+
             ```
             ${{ steps.lint_pr_title.outputs.error_message }}
             ```
       # Delete a previous comment when the issue has been resolved
       - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
         uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2
-        with:   
+        with:
           header: pr-title-lint-error
           delete: true

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -15,7 +15,8 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5
+      - id: lint_pr_title
+        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ jobs:
   release-package:
     environment: publish
     runs-on: windows-latest
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - uses: google-github-actions/release-please-action@db8f2c60ee802b3748b512940dde88eabd7b7e01 # v3


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to explicitly define permissions for improved security and functionality. Additionally, it includes a minor change to the `lint-pr.yml` file for consistency in string formatting and an enhancement to the linting step.

### Permissions Updates:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR21-R24): Added `contents: read` and `pull-requests: write` permissions to the `jobs` section for both the default CI job and the `e2e` job. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR21-R24) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR51-R53)
* [`.github/workflows/lint-pr.yml`](diffhunk://#diff-70c3a017bfdb629fd50281fe5f7ad22e29c0ddac36e7065e9dc6d4f0924104f4R13-R19): Added `contents: read` and `pull-requests: write` permissions to the `main` job.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R12-R14): Added `contents: read` and `pull-requests: write` permissions to the `release-package` job.

### Minor Improvements:
* [`.github/workflows/lint-pr.yml`](diffhunk://#diff-70c3a017bfdb629fd50281fe5f7ad22e29c0ddac36e7065e9dc6d4f0924104f4L1-R1): Changed single quotes to double quotes in the workflow name for consistency.
* [`.github/workflows/lint-pr.yml`](diffhunk://#diff-70c3a017bfdb629fd50281fe5f7ad22e29c0ddac36e7065e9dc6d4f0924104f4R13-R19): Enhanced the `Validate PR title` step by adding an `id` field (`lint_pr_title`) to improve reusability and clarity.