### PR TITLE
chore(deps): update SDK version

### DIFF
--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
 
       - name: Setup .NET
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -27,7 +27,10 @@ jobs:
           source-url: https://nuget.pkg.github.com/open-feature/index.json
 
       - name: Restore
-        run: dotnet restore DotnetSdkContrib.sln
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore
 
       - name: dotnet format
         run: dotnet format --verify-no-changes --no-restore DotnetSdkContrib.sln

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -26,5 +26,8 @@ jobs:
           global-json-file: global.json
           source-url: https://nuget.pkg.github.com/open-feature/index.json
 
+      - name: Restore
+        run: dotnet restore DotnetSdkContrib.sln
+
       - name: dotnet format
-        run: dotnet format --verify-no-changes DotnetSdkContrib.sln
+        run: dotnet format --verify-no-changes --no-restore DotnetSdkContrib.sln

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
     "sdk": {
         "rollForward": "latestFeature",
-        "version": "8.0.408",
+        "version": "9.0.202",
         "allowPrerelease": false
     }
 }

--- a/src/OpenFeature.Contrib.Providers.Flipt/OpenFeature.Contrib.Providers.Flipt.csproj
+++ b/src/OpenFeature.Contrib.Providers.Flipt/OpenFeature.Contrib.Providers.Flipt.csproj
@@ -39,6 +39,6 @@
 
     <Target Name="NSwag" BeforeTargets="BeforeBuild">
         <Exec
-            Command="$(NSwagExe_Net80) openapi2csclient /className:FliptRestClient /namespace:Flipt.Rest /input:&quot;openapi.yaml&quot; /output:&quot;$(ProjectDir)obj/$(ConfigurationName)/$(TargetFramework)/Flipt.Rest.Client.cs&quot; /GenerateExceptionClasses:true /OperationGenerationMode:SingleClientFromPathSegments /JsonLibrary:SystemTextJson /GenerateOptionalParameters:true /GenerateDefaultValues:true /GenerateResponseClasses:true /GenerateClientInterfaces:true /GenerateClientClasses:true /GenerateDtoTypes:true /ExceptionClass:FliptRestException /GenerateNativeRecords:true /UseBaseUrl:false /GenerateBaseUrlProperty:false" />
+            Command="$(NSwagExe_Net90) openapi2csclient /className:FliptRestClient /namespace:Flipt.Rest /input:&quot;openapi.yaml&quot; /output:&quot;$(ProjectDir)obj/$(ConfigurationName)/$(TargetFramework)/Flipt.Rest.Client.cs&quot; /GenerateExceptionClasses:true /OperationGenerationMode:SingleClientFromPathSegments /JsonLibrary:SystemTextJson /GenerateOptionalParameters:true /GenerateDefaultValues:true /GenerateResponseClasses:true /GenerateClientInterfaces:true /GenerateClientClasses:true /GenerateDtoTypes:true /ExceptionClass:FliptRestException /GenerateNativeRecords:true /UseBaseUrl:false /GenerateBaseUrlProperty:false" />
     </Target>
 </Project>


### PR DESCRIPTION
This pull request updates the build and formatting workflows, upgrades the .NET SDK version, and modifies the NSwag configuration to align with the new SDK version. These changes aim to improve compatibility, streamline the build process, and ensure proper code formatting.

### Workflow updates:
* Updated the `.github/workflows/dotnet-format.yml` file to include `fetch-depth: 0` and `submodules: recursive` in the checkout step, ensuring all history and submodules are fetched.
* Added `dotnet restore` and `dotnet build --no-restore` steps to the workflow before running `dotnet format`, and modified the `dotnet format` command to include the `--no-restore` flag for efficiency.

### SDK version upgrade:
* Updated the `global.json` file to use .NET SDK version `9.0.202`, replacing the previous version `8.0.408`.

### NSwag configuration update:
* Updated the `Command` in `OpenFeature.Contrib.Providers.Flipt.csproj` to use `NSwagExe_Net90` instead of `NSwagExe_Net80`, ensuring compatibility with the upgraded .NET SDK. @markphelps is this okay for you?