### PR TITLE
ci: Update release workflow to find csproj file dynamically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,11 +71,16 @@ jobs:
         with:
           subject-path: "${{ matrix.release }}/**/*.nupkg"
 
+      - name: Find csproj file and set as environment variable
+        id: find-csproj
+        run: |
+          csproj_path=$(find "${{ matrix.release }}" -name '*.csproj' -type f -print -quit)
+          echo "CSPROJ_PATH=$csproj_path" >> "$GITHUB_OUTPUT"
+
       - name: Generate JSON SBOM
         uses: CycloneDX/gh-dotnet-generate-sbom@c183e4ac30e5b99354cb9a98c38548e07c538346 # v1.0.1
         with:
-          path: "${{ matrix.release }}/**/*.csproj"
-          out: ./artifacts/sboms
+          path: ${{ steps.find-csproj.outputs.CSPROJ_PATH }}
           json: true
           github-bearer-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -83,9 +88,9 @@ jobs:
         uses: actions/attest-sbom@115c3be05ff3974bcbd596578934b3f9ce39bf68 # v2.2.0
         with:
           subject-path: "${{ matrix.release }}/**/*.nupkg"
-          sbom-path: artifacts/sboms/bom.json
+          sbom-path: bom.json
 
       - name: Attach SBOM to artifact
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        run: gh release upload ${{ needs.release-package.outputs.release_tag_name }} artifacts/sboms/bom.json
+        run: gh release upload ${{ needs.release-package.outputs.release_tag_name }} bom.json


### PR DESCRIPTION
…just SBOM paths

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request updates the `.github/workflows/release.yml` file to improve the handling of `.csproj` files and simplify the SBOM generation and upload process. The changes ensure more precise file identification and streamline the workflow steps.

**Workflow improvements:**

* Added a step to dynamically find the `.csproj` file in the release directory and set its path as an environment variable (`CSPROJ_PATH`). This replaces the previous wildcard-based approach for specifying the `.csproj` path.
* Updated the SBOM generation step to use the dynamically determined `.csproj` path instead of a hardcoded pattern.

**Simplification of SBOM handling:**

* Changed the SBOM output path from `artifacts/sboms/bom.json` to `bom.json` for simplicity.
* Updated the SBOM upload step to reflect the new simplified path.

### Notes
I found that cycloneDX action doesn't like to resolve paths. I added a script that finds the csproj based on the path so we generate the SBOMs for the released package.
Test run here: https://github.com/open-feature/dotnet-sdk-contrib/actions/runs/14912787947 (I was using this workflow as a test for the path/action creation)