### PR TITLE
test: Fix flagd test shutdown

### DIFF
--- a/test/OpenFeature.Contrib.Providers.Flagd.Test/FlagdProviderTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagd.Test/FlagdProviderTest.cs
@@ -205,6 +205,8 @@ public class UnitTestFlagdProvider
         var val = await flagdProvider.ResolveBooleanValueAsync("my-key", false);
 
         Assert.True(val.Value);
+
+        await flagdProvider.ShutdownAsync();
     }
 
     [Fact]
@@ -231,6 +233,8 @@ public class UnitTestFlagdProvider
         var val = await flagdProvider.ResolveStringValueAsync("my-key", "");
 
         Assert.Equal("my-value", val.Value);
+
+        await flagdProvider.ShutdownAsync();
     }
 
     [Fact]
@@ -258,6 +262,8 @@ public class UnitTestFlagdProvider
         var val = await flagdProvider.ResolveIntegerValueAsync("my-key", 0);
 
         Assert.Equal(10, val.Value);
+
+        await flagdProvider.ShutdownAsync();
     }
 
     [Fact]
@@ -285,6 +291,8 @@ public class UnitTestFlagdProvider
         var val = await flagdProvider.ResolveDoubleValueAsync("my-key", 0.0);
 
         Assert.Equal(10.0, val.Value);
+
+        await flagdProvider.ShutdownAsync();
     }
 
     [Fact]
@@ -315,6 +323,8 @@ public class UnitTestFlagdProvider
         var val = await flagdProvider.ResolveStructureValueAsync("my-key", null);
 
         Assert.True(val.Value.AsStructure.ContainsKey("my-key"));
+
+        await flagdProvider.ShutdownAsync();
     }
 
     [Fact]
@@ -347,6 +357,8 @@ public class UnitTestFlagdProvider
             Assert.Equal(ErrorType.FlagNotFound, ex.ErrorType);
             Assert.Equal(ErrorType.FlagNotFound.ToString(), ex.Message);
         });
+
+        await flagdProvider.ShutdownAsync();
     }
 
     [Fact]
@@ -380,6 +392,8 @@ public class UnitTestFlagdProvider
             Assert.Equal(ErrorType.ProviderNotReady, ex.ErrorType);
             Assert.Equal(ErrorType.ProviderNotReady.ToString(), ex.Message);
         });
+
+        await flagdProvider.ShutdownAsync();
     }
 
     [Fact]
@@ -413,6 +427,8 @@ public class UnitTestFlagdProvider
             Assert.Equal(ErrorType.TypeMismatch, ex.ErrorType);
             Assert.Equal(ErrorType.TypeMismatch.ToString(), ex.Message);
         });
+
+        await flagdProvider.ShutdownAsync();
     }
 
     [Fact]
@@ -446,6 +462,8 @@ public class UnitTestFlagdProvider
             Assert.Equal(ErrorType.General, ex.ErrorType);
             Assert.Equal(ErrorType.General.ToString(), ex.Message);
         });
+
+        await flagdProvider.ShutdownAsync();
     }
 
     [Fact]
@@ -695,6 +713,8 @@ public class UnitTestFlagdProvider
         mockCache.Received(2).Add("my-key", Arg.Any<object>());
         mockCache.Received().Delete("my-key");
         mockGrpcClient.Received(Quantity.AtLeastOne()).EventStream(Arg.Any<EventStreamRequest>(), null, null, CancellationToken.None);
+
+        await flagdProvider.ShutdownAsync();
     }
 
     [Fact]
@@ -753,6 +773,8 @@ public class UnitTestFlagdProvider
             });
 
         mockGrpcClient.Received(Quantity.AtLeastOne()).SyncFlags(Arg.Is<SyncFlagsRequest>(req => req.Selector == "source-selector"), null, null, CancellationToken.None);
+
+        await flagdProvider.ShutdownAsync();
     }
 
     [Fact]
@@ -811,5 +833,7 @@ public class UnitTestFlagdProvider
             });
 
         mockGrpcClient.Received(Quantity.AtLeastOne()).SyncFlags(Arg.Is<SyncFlagsRequest>(req => req.Selector == "source-selector"), null, null, CancellationToken.None);
+
+        await flagdProvider.ShutdownAsync();
     }
 }

--- a/test/OpenFeature.Contrib.Providers.Flagd.Test/FlagdProviderTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagd.Test/FlagdProviderTest.cs
@@ -523,6 +523,8 @@ public class UnitTestFlagdProvider
         mockCache.Received(1).TryGet(Arg.Is<string>(s => s == "my-key"));
         mockCache.Received(1).Add(Arg.Is<string>(s => s == "my-key"), Arg.Any<object>());
         mockGrpcClient.Received(Quantity.AtLeastOne()).EventStream(Arg.Any<EventStreamRequest>(), null, null, CancellationToken.None);
+
+        await flagdProvider.ShutdownAsync();
     }
 
     [Fact]
@@ -587,6 +589,8 @@ public class UnitTestFlagdProvider
         Assert.True(_autoResetEvent.WaitOne(10000));
         mockCache.Received(1).TryGet("my-key");
         mockGrpcClient.Received(Quantity.AtLeastOne()).EventStream(Arg.Any<EventStreamRequest>(), null, null, CancellationToken.None);
+
+        await flagdProvider.ShutdownAsync();
     }
 
     [Fact]


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request adds calls to `flagdProvider.ShutdownAsync()` at the end of multiple test methods in `FlagdProviderTest.cs` to ensure proper resource cleanup after each test execution. These changes improve the test suite's reliability and maintainability.

### Test Cleanup Enhancements:
* Added `await flagdProvider.ShutdownAsync();` to the following test methods to ensure the provider is properly shut down after each test:
  - `TestResolveBooleanValueAsync`
  - `TestResolveStringValue`
  - `TestResolveIntegerValue`
  - `TestResolveDoubleValue`
  - `TestResolveStructureValue`
  - `TestResolveFlagNotFound`
  - `TestResolveGrpcHostUnavailable`
  - `TestResolveTypeMismatch`
  - `TestResolveUnknownError`
  - `TestCacheAsync`
  - `TestCacheHitAsync`
  - `TestCacheInvalidationAsync`
  - Additional test cases using `Utils.AssertUntilAsync` [[1]](diffhunk://#diff-09d8b886680e5c2db397b8a6f70fdc4d01ddb2f2d912877e77f5d300e67f860bR776-R777) [[2]](diffhunk://#diff-09d8b886680e5c2db397b8a6f70fdc4d01ddb2f2d912877e77f5d300e67f860bR836-R837)

### Notes
<!-- any additional notes for this PR -->
While I was running some tests locally, I noticed the test thread was not being killed. After a few sessions of debugging, I found that we were not disposing of the `flagd` provider.