### PR TITLE
ci: Fix SBOM path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,8 @@ jobs:
     strategy:
       matrix:
         release: ${{ fromJSON(needs.release-package.outputs.paths_released) }}
-        all: ${{ toJSON(needs.release-package.outputs) }}
+    env:
+      TAG: ${{ fromJSON(needs.release-package.outputs.all)[format('{0}--tag_name', matrix.release)] }}
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,8 @@ jobs:
         with:
           token: ${{secrets.RELEASE_PLEASE_ACTION_TOKEN}}
     outputs:
-      release_created: ${{ fromJSON(steps.release.outputs.paths_released)[0] != null }} # if we have a single release path, do the release
-      # release_tag_name: ${{ steps.release.outputs.release_tag_name }}
+      all: ${{ toJSON(steps.release.outputs) }}
+      releases_created: ${{ steps.release.outputs.releases_created }}
       paths_released: ${{ steps.release.outputs.paths_released }}
 
   release:
@@ -32,10 +32,11 @@ jobs:
       contents: write # upload sbom to a release
       attestations: write
       packages: read # for internal nuget reading
-    if: ${{ needs.release-package.outputs.release_created }}
+    if: ${{ needs.release-package.outputs.releases_created }}
     strategy:
       matrix:
         release: ${{ fromJSON(needs.release-package.outputs.paths_released) }}
+        all: ${{ toJSON(needs.release-package.outputs) }}
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       contents: write # upload sbom to a release
       attestations: write
       packages: read # for internal nuget reading
-    if: ${{ needs.release-package.outputs.releases_created }}
+    if: ${{ fromJSON(needs.release-package.outputs.releases_created || false) }}
     strategy:
       matrix:
         release: ${{ fromJSON(needs.release-package.outputs.paths_released) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         release: ${{ fromJSON(needs.release-package.outputs.paths_released) }}
     env:
-      TAG: ${{ fromJSON(needs.release-package.outputs.all)[format('{0}--tag_name', matrix.release)] }}
+      TAG_NAME: ${{ fromJSON(needs.release-package.outputs.all)[format('{0}--tag_name', matrix.release)] }}
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -92,9 +92,7 @@ jobs:
           subject-path: "${{ matrix.release }}/**/*.nupkg"
           sbom-path: bom.json
 
-      # TODO: We need to look into this link and fix the tag_name https://github.com/googleapis/release-please-action?tab=readme-ov-file#outputs
-      # Because we are using a multiple release path, we need to use the <path>--tag_name from the release-package job
-      # - name: Attach SBOM to artifact
-      #   env:
-      #     GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      #   run: gh release upload ${{ needs.release-package.outputs.release_tag_name }} bom.json
+      - name: Attach SBOM to artifact
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: gh release upload ${{ env.TAG_NAME }} bom.json


### PR DESCRIPTION
Signed-off-by: André Silva <2493377+askpt@users.noreply.github.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request updates the `.github/workflows/release.yml` file to improve the handling of multiple release paths and streamline the release process. The key changes include adjustments to outputs, conditions, and environment variables, as well as the reintroduction of a previously commented-out step for attaching SBOMs to artifacts.

### Workflow Enhancements:

* **Updated Outputs for Release Package Job**: Changed outputs to include `all` (JSON object of all outputs) and `releases_created` (replacing `release_created`) for better handling of multiple release paths. (`[.github/workflows/release.ymlL22-R23](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L22-R23)`)
* **Condition Update in Release Job**: Modified the `if` condition to use `releases_created` instead of `release_created`, aligning with the new output structure. (`[.github/workflows/release.ymlL35-R40](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L35-R40)`)
* **Environment Variable for Tag Name**: Added an `env` variable `TAG_NAME` to dynamically compute the tag name based on the release path, enabling support for multiple release paths. (`[.github/workflows/release.ymlL35-R40](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L35-R40)`)

### Reintroduction of SBOM Attachment:

* **Attach SBOM to Artifact**: Reinstated the previously commented-out step to upload the SBOM (`bom.json`) to the release, using the dynamically computed `TAG_NAME`. (`[.github/workflows/release.ymlL93-R98](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L93-R98)`)

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #96 

### Notes
<!-- any additional notes for this PR -->
I followed the GO contrib implementation here: https://github.com/open-feature/go-sdk-contrib/blob/main/.github/workflows/release-please.yaml