### PR TITLE
feat: Add Dependency Injection extensions for Adding Flagd Provider

### DIFF
--- a/src/OpenFeature.Contrib.Providers.Flagd/DependencyInjection/FeatureBuilderExtensions.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/DependencyInjection/FeatureBuilderExtensions.cs
@@ -1,0 +1,111 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using OpenFeature.Contrib.Providers.Flagd;
+
+namespace OpenFeature.DependencyInjection.Providers.Flagd;
+
+/// <summary>
+/// Extension methods for configuring the <see cref="OpenFeatureBuilder"/>.
+/// </summary>
+public static class FeatureBuilderExtensions
+{
+    /// <summary>
+    /// Adds the <see cref="FlagdProvider"/> to the <see cref="OpenFeatureBuilder"/> with default <see cref="FlagdProviderOptions"/> configuration.
+    /// </summary>
+    /// <param name="builder">The <see cref="OpenFeatureBuilder"/> instance to configure.</param>
+    /// <returns>The <see cref="OpenFeatureBuilder"/> instance for chaining.</returns>
+    public static OpenFeatureBuilder AddFlagdProvider(this OpenFeatureBuilder builder)
+        => builder.AddProvider(sp =>
+        {
+            return CreateProvider(sp, null, null);
+        });
+
+    /// <summary>
+    /// Adds the <see cref="FlagdProvider"/> to the <see cref="OpenFeatureBuilder"/> with specified <see cref="FlagdProviderOptions"/> configuration.
+    /// </summary>
+    /// <param name="builder">The <see cref="OpenFeatureBuilder"/> instance to configure.</param>
+    /// <param name="configureOptions">Delegate to configure the <see cref="FlagdProvider"/>.</param>
+    /// <returns>The <see cref="OpenFeatureBuilder"/> instance for chaining.</returns>
+    public static OpenFeatureBuilder AddFlagdProvider(this OpenFeatureBuilder builder, Action<FlagdProviderOptions> configureOptions)
+        => builder.AddProvider(sp =>
+        {
+            return CreateProvider(sp, null, configureOptions);
+        });
+
+    /// <summary>
+    /// Adds the <see cref="FlagdProvider"/> to the <see cref="OpenFeatureBuilder"/> with a specific domain and <see cref="FlagdProviderOptions"/> configuration.
+    /// </summary>
+    /// <param name="builder">The <see cref="OpenFeatureBuilder"/> instance to configure.</param>
+    /// <param name="domain">The unique domain of the provider.</param>
+    /// <param name="configureOptions">Delegate to configure the <see cref="FlagdProvider"/>.</param>
+    /// <returns>The <see cref="OpenFeatureBuilder"/> instance for chaining.</returns>
+    public static OpenFeatureBuilder AddFlagdProvider(this OpenFeatureBuilder builder, string domain, Action<FlagdProviderOptions> configureOptions)
+        => builder.AddProvider(domain, (sp, domain) =>
+        {
+            return CreateProvider(sp, domain, configureOptions);
+        });
+
+    /// <summary>
+    /// Adds the <see cref="FlagdProvider"/> to the <see cref="OpenFeatureBuilder"/> with <see cref="FlagdProviderOptions"/> configuration.
+    /// </summary>
+    /// <param name="builder">The <see cref="OpenFeatureBuilder"/> instance to configure.</param>
+    /// <param name="options">Options to configure <see cref="FlagdProvider"/>.</param>
+    /// <returns>The <see cref="OpenFeatureBuilder"/> instance for chaining.</returns>
+    public static OpenFeatureBuilder AddFlagdProvider(this OpenFeatureBuilder builder, FlagdProviderOptions options)
+        => builder.AddProvider(sp =>
+        {
+            return CreateProvider(sp, null, o => { o = options; });
+        });
+
+    /// <summary>
+    /// Adds the <see cref="FlagdProvider"/> to the <see cref="OpenFeatureBuilder"/> with a specific domain and default <see cref="FlagdProviderOptions"/> configuration.
+    /// </summary>
+    /// <param name="builder">The <see cref="OpenFeatureBuilder"/> instance to configure.</param>
+    /// <param name="domain">The unique domain of the provider.</param>
+    /// <returns>The <see cref="OpenFeatureBuilder"/> instance for chaining.</returns>
+    public static OpenFeatureBuilder AddFlagdProvider(this OpenFeatureBuilder builder, string domain)
+        => builder.AddProvider(domain, (sp, domain) =>
+        {
+            return CreateProvider(sp, domain, null);
+        });
+
+    /// <summary>
+    /// Adds the <see cref="FlagdProvider"/> to the <see cref="OpenFeatureBuilder"/> with a specific domain and <see cref="FlagdProviderOptions"/> configuration.
+    /// </summary>
+    /// <param name="builder">The <see cref="OpenFeatureBuilder"/> instance to configure.</param>
+    /// <param name="domain">The unique domain of the provider.</param>
+    /// <param name="options">Options to configure <see cref="FlagdProvider"/>.</param>
+    /// <returns>The <see cref="OpenFeatureBuilder"/> instance for chaining.</returns>
+    public static OpenFeatureBuilder AddFlagdProvider(this OpenFeatureBuilder builder, string domain, FlagdProviderOptions options)
+        => builder.AddProvider(domain, (sp, domain) =>
+        {
+            return CreateProvider(sp, domain, o => { o = options; });
+        });
+
+    private static FlagdProvider CreateProvider(IServiceProvider provider, string _, Action<FlagdProviderOptions> configureOptions)
+    {
+        var logger = provider.GetService<ILogger<FlagdProvider>>();
+        var options = new FlagdProviderOptions();
+
+        configureOptions?.Invoke(options);
+        logger ??= NullLogger<FlagdProvider>.Instance;
+
+        var config = FlagdConfig.Builder()
+            .WithHost(options.Host)
+            .WithPort(options.Port)
+            .WithTls(options.UseTls)
+            .WithCache(options.CacheEnabled)
+            .WithMaxCacheSize(options.MaxCacheSize)
+            .WithCertificatePath(options.CertificatePath)
+            .WithSocketPath(options.SocketPath)
+            .WithMaxEventStreamRetries(options.MaxEventStreamRetries)
+            .WithResolverType(options.ResolverType)
+            .WithSourceSelector(options.SourceSelector)
+            .WithLogger(logger)
+            .Build();
+
+        return new FlagdProvider(config);
+    }
+}

--- a/src/OpenFeature.Contrib.Providers.Flagd/DependencyInjection/FlagdProviderOptions.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/DependencyInjection/FlagdProviderOptions.cs
@@ -1,0 +1,169 @@
+using OpenFeature.Contrib.Providers.Flagd;
+
+namespace OpenFeature.DependencyInjection.Providers.Flagd;
+
+/// <summary>
+/// Configuration options for the Flagd provider.
+/// </summary>
+public record FlagdProviderOptions
+{
+    /// <summary>
+    /// The host for the provider to connect to. Defaults to "localhost".
+    /// </summary>
+    public string Host { get; init; } = "localhost";
+
+    /// <summary>
+    /// The Port property of the config. Defaults to 8013.
+    /// </summary>
+    public int Port { get; init; } = 8013;
+
+    /// <summary>
+    /// Use TLS for communication between the provider and the host. Defaults to false.
+    /// </summary>
+    public bool UseTls { get; init; } = false;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public bool CacheEnabled { get; init; } = false;
+
+    /// <summary>
+    /// The maximum size of the cache. Defaults to 10.
+    /// </summary>
+    public int MaxCacheSize { get; init; } = 10;
+
+    /// <summary>
+    /// Path to the certificate file. Defaults to empty string.
+    /// </summary>
+    public string CertificatePath { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Path to the socket. Defaults to empty string.
+    /// </summary>
+    public string SocketPath { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Maximum number of times the connection to the event stream should be re-attempted. Defaults to 3.
+    /// </summary>
+    public int MaxEventStreamRetries { get; init; } = 3;
+
+    /// <summary>
+    /// Which type of resolver to use. Defaults to <see cref="ResolverType.RPC"/>.
+    /// </summary>
+    public ResolverType ResolverType { get; init; } = ResolverType.RPC;
+
+    /// <summary>
+    /// Source selector for the in-process provider. Defaults to empty string.
+    /// </summary>
+    public string SourceSelector { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The host for the provider to connect to.
+    /// </summary>
+    public FlagdProviderOptions WithHost(string host)
+    {
+        return this with
+        {
+            Host = host
+        };
+    }
+
+    /// <summary>
+    /// The Port property of the config.
+    /// </summary>
+    public FlagdProviderOptions WithPort(int port)
+    {
+        return this with
+        {
+            Port = port
+        };
+    }
+
+    /// <summary>
+    /// Use TLS for communication between the provider and the host.
+    /// </summary>
+    public FlagdProviderOptions WithTls(bool useTls)
+    {
+        return this with
+        {
+            UseTls = useTls
+        };
+    }
+
+    /// <summary>
+    /// Path to the certificate file.
+    /// </summary>
+    public FlagdProviderOptions WithCertificatePath(string certPath)
+    {
+        return this with
+        {
+            CertificatePath = certPath
+        };
+    }
+
+    /// <summary>
+    /// Path to the socket.
+    /// </summary>
+    public FlagdProviderOptions WithSocketPath(string socketPath)
+    {
+        return this with
+        {
+            SocketPath = socketPath
+        };
+    }
+
+    /// <summary>
+    /// Enable/disable the local cache for static flag values.
+    /// </summary>
+    public FlagdProviderOptions WithCache(bool cacheEnabled)
+    {
+        return this with
+        {
+            CacheEnabled = cacheEnabled
+        };
+    }
+
+    /// <summary>
+    /// The maximum size of the cache.
+    /// </summary>
+    public FlagdProviderOptions WithMaxCacheSize(int maxCacheSize)
+    {
+        return this with
+        {
+            MaxCacheSize = maxCacheSize
+        };
+    }
+
+    /// <summary>
+    /// Maximum number of times the connection to the event stream should be re-attempted
+    /// </summary>
+    public FlagdProviderOptions WithMaxEventStreamRetries(int maxEventStreamRetries)
+    {
+        return this with
+        {
+            MaxEventStreamRetries = maxEventStreamRetries
+        };
+    }
+
+    /// <summary>
+    /// Which type of resolver to use.
+    /// </summary>
+    public FlagdProviderOptions WithResolverType(ResolverType resolverType)
+    {
+        return this with
+        {
+            ResolverType = resolverType
+        };
+    }
+
+    /// <summary>
+    /// Source selector for the in-process provider.
+    /// </summary>
+    public FlagdProviderOptions WithSourceSelector(string sourceSelector)
+    {
+        return this with
+        {
+            SourceSelector = sourceSelector
+        };
+    }
+}

--- a/src/OpenFeature.Contrib.Providers.Flagd/OpenFeature.Contrib.Providers.Flagd.csproj
+++ b/src/OpenFeature.Contrib.Providers.Flagd/OpenFeature.Contrib.Providers.Flagd.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <PackageId>OpenFeature.Contrib.Providers.Flagd</PackageId>
@@ -36,8 +36,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0"
-      Condition="'$(TargetFramework)' == 'netstandard2.0'" />
-    <PackageReference Include="OpenFeature" Version="[2.0,3.0)" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="OpenFeature" Version="[2.2,3.0)" />
+    <PackageReference Include="OpenFeature.DependencyInjection" Version="[2.2,3.0)" />
   </ItemGroup>
 </Project>

--- a/test/OpenFeature.Contrib.Providers.Flagd.Test/FeatureBuilderExtensionsTests.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagd.Test/FeatureBuilderExtensionsTests.cs
@@ -1,0 +1,75 @@
+using Microsoft.Extensions.DependencyInjection;
+using OpenFeature.DependencyInjection.Providers.Flagd;
+using Xunit;
+
+namespace OpenFeature.Contrib.Providers.Flagd.Test;
+
+public class FeatureBuilderExtensionsTests
+{
+    [Fact]
+    public void AddFlagdProvider_WithNoConfiguration_ShouldReturnOpenFeatureBuilder()
+    {
+        // Arrange
+        using var services = new ServiceCollection()
+            .AddOpenFeature(builder =>
+            {
+                // Act
+                builder.AddFlagdProvider();
+            })
+            .BuildServiceProvider();
+
+        // Assert
+        var client = services.GetService<IFeatureClient>();
+        Assert.NotNull(client);
+
+        var provider = services.GetService<FeatureProvider>();
+        Assert.NotNull(provider);
+        Assert.Equal("flagd Provider", provider.GetMetadata().Name);
+    }
+
+    [Fact]
+    public void AddFlagdProvider_ShouldReturnOpenFeatureBuilder()
+    {
+        // Arrange
+        using var services = new ServiceCollection()
+            .AddOpenFeature(builder =>
+            {
+                // Act
+                builder.AddFlagdProvider(new FlagdProviderOptions
+                {
+                    Host = "localhost"
+                });
+            })
+            .BuildServiceProvider();
+
+        // Assert
+        var client = services.GetService<IFeatureClient>();
+        Assert.NotNull(client);
+
+        var provider = services.GetService<FeatureProvider>();
+        Assert.NotNull(provider);
+        Assert.Equal("flagd Provider", provider.GetMetadata().Name);
+    }
+
+    [Fact]
+    public void AddFlagdProvider_WithConfigBuilderDelegate_ShouldReturnOpenFeatureBuilder()
+    {
+        // Arrange
+        using var services = new ServiceCollection()
+            .AddOpenFeature(builder =>
+            {
+                // Act
+                builder.AddFlagdProvider(config => config
+                    .WithHost("localhost"));
+            })
+            .BuildServiceProvider();
+
+        // Assert
+        var client = services.GetService<IFeatureClient>();
+        Assert.NotNull(client);
+
+        var provider = services.GetService<FeatureProvider>();
+        Assert.NotNull(provider);
+        Assert.Equal("flagd Provider", provider.GetMetadata().Name);
+    }
+}


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

_Submitting this as draft for API review and discussion._

Adds extension methods to OpenFeatureBuilder for adding and configuring the FlagdProvider.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #376

### Notes
<!-- any additional notes for this PR -->

If we're going to add these Extension methods we need to bump the OpenFeature dependency up to >2.2.0. I'm not certain how we want consumers to be using this API to inject the Flagd provider. At the moment I added a delegate approach with builder-like methods for chaining configuration calls. I also added methods that allow consumers to create FlagdProviderOptions and set the property values as they like.

__Delegate approach__

```csharp
builder.Services.AddOpenFeature(config =>
{
    config.AddHostedFeatureLifecycle()
        .AddFlagdProvider(options => options
            .WithHost("localhost")
            .WithPort(8013)
            .WithTls(true))
         .AddFlagdProvider("domain1", options => options
            .WithHost("localhost")
         );
});
```

__Property initialization approach__

```csharp
builder.Services.AddOpenFeature(config =>
{
    config.AddHostedFeatureLifecycle()
        .AddFlagdProvider(new FlagdProviderOptions
            {
                Host = "localhost",
                Port = 8013,
                UseTls = true
            })
        .AddFlagdProvider("domain1", new FlagdProviderOptions
            {
                Host = "localhost"
            })
        );
});
```

I need to finish unit testing and ensuring code coverage is sufficient, but before I proceed I wanted to discuss with others what the API should look like.

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

I have created an integration test to help test that the extension methods are working as expected. However, for some reason `OpenFeature.Hosting` only targets net8 and net9. The tests in dotnet-sdk-contrib target net462, net8, and net9. So I'd have to drop net462 as a tfm to keep this test.

### How to test
<!-- if applicable, add testing instructions under this section -->

