### PR TITLE
docs: Add deprecation notice to OTEL lib

### DIFF
--- a/src/OpenFeature.Contrib.Hooks.Otel/OpenFeature.Contrib.Hooks.Otel.csproj
+++ b/src/OpenFeature.Contrib.Hooks.Otel/OpenFeature.Contrib.Hooks.Otel.csproj
@@ -9,11 +9,16 @@
     <Description>Open Telemetry Hook for .NET</Description>
     <Authors>Florian Bacher</Authors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="OpenTelemetry.Api" Version="1.9.0" />
     <PackageReference Include="OpenFeature" Version="[2.0,3.0)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenFeature.Contrib.Hooks.Otel/README.md
+++ b/src/OpenFeature.Contrib.Hooks.Otel/README.md
@@ -223,48 +223,6 @@ namespace OpenFeatureTestApp
 
 After running this example, you should be able to see some metrics being generated into the console.
 
-### Modern Metrics Example (SDK v2.7.0+)
-
-Here's how to achieve the same functionality using the native `MetricsHook` in the OpenFeature SDK:
-
-```csharp
-using OpenFeature.Contrib.Providers.Flagd;
-using OpenFeature;
-using OpenFeature.Hooks; // Use the native SDK hooks
-using OpenTelemetry;
-using OpenTelemetry.Metrics;
-
-namespace OpenFeatureTestApp
-{
-    class Hello {
-        static void Main(string[] args) {
-
-            // set up the OpenTelemetry OTLP exporter
-            var meterProvider = Sdk.CreateMeterProviderBuilder()
-                    .AddMeter("OpenFeature") // Note: different meter name for SDK
-                    .ConfigureResource(r => r.AddService("openfeature-test"))
-                    .AddConsoleExporter()
-                    .Build();
-
-            // add the native SDK MetricsHook to the OpenFeature instance
-            OpenFeature.Api.Instance.AddHooks(new MetricsHook());
-
-            var flagdProvider = new FlagdProvider(new Uri("http://localhost:8013"));
-
-            // Set the flagdProvider as the provider for the OpenFeature SDK
-            OpenFeature.Api.Instance.SetProvider(flagdProvider);
-
-            var client = OpenFeature.Api.Instance.GetClient("my-app");
-
-            var val = client.GetBooleanValueAsync("myBoolFlag", false, null);
-
-            // Print the value of the 'myBoolFlag' feature flag
-            System.Console.WriteLine(val.Result.ToString());
-        }
-    }
-}
-```
-
 ## License
 
 Apache 2.0 - See [LICENSE](./../../LICENSE) for more information.

--- a/src/OpenFeature.Contrib.Hooks.Otel/README.md
+++ b/src/OpenFeature.Contrib.Hooks.Otel/README.md
@@ -1,17 +1,111 @@
 # OpenFeature OpenTelemetry hook for .NET
 
-## Requirements
+> **⚠️ DEPRECATED**: This library is now deprecated. OpenTelemetry hooks have been moved to the main OpenFeature .NET SDK starting with version 2.7.0. Please migrate to the native hooks provided in the SDK.
 
-- open-feature/dotnet-sdk v1.5.0 > v2.0.0
+## Migration Guide
 
-## Usage - Traces
+As of OpenFeature .NET SDK version 2.7.0, OpenTelemetry hooks are now included natively in the SDK and this contrib library is no longer needed. Follow these steps to migrate:
+
+### 1. Update Dependencies
+
+Remove this package:
+
+```xml
+<PackageReference Include="OpenFeature.Contrib.Hooks.Otel" Version="..." />
+```
+
+Update to the latest OpenFeature SDK:
+
+```xml
+<PackageReference Include="OpenFeature" Version="2.7.0" />
+```
+
+### 2. Update Using Statements
+
+**Before:**
+
+```csharp
+using OpenFeature.Contrib.Hooks.Otel;
+```
+
+**After:**
+
+```csharp
+using OpenFeature.Hooks;
+```
+
+### 3. Update Hook Class Names
+
+The hook classes have been renamed and improved:
+
+| Old Class Name (Contrib) | New Class Name (SDK) | Purpose                                              |
+| ------------------------ | -------------------- | ---------------------------------------------------- |
+| `TracingHook`            | `TraceEnricherHook`  | Enriches traces with feature flag evaluation details |
+| `MetricsHook`            | `MetricsHook`        | Collects metrics for feature flag evaluations        |
+
+### 4. Update Your Code
+
+**Before (using contrib library):**
+
+```csharp
+// Tracing
+OpenFeature.Api.Instance.AddHooks(new TracingHook());
+
+// Metrics
+OpenFeature.Api.Instance.AddHooks(new MetricsHook());
+```
+
+**After (using native SDK hooks):**
+
+```csharp
+// Tracing - now called TraceEnricherHook
+OpenFeature.Api.Instance.AddHooks(new TraceEnricherHook());
+
+// Metrics - same name but from different namespace
+OpenFeature.Api.Instance.AddHooks(new MetricsHook());
+```
+
+### 5. Updated Metrics
+
+The native `MetricsHook` in the SDK provides enhanced metrics with improved dimensions:
+
+| Metric Name                              | Description                     | Unit           | Dimensions                                  |
+| ---------------------------------------- | ------------------------------- | -------------- | ------------------------------------------- |
+| `feature_flag.evaluation_requests_total` | Number of evaluation requests   | `{request}`    | `key`, `provider_name`                      |
+| `feature_flag.evaluation_success_total`  | Flag evaluation successes       | `{impression}` | `key`, `provider_name`, `reason`, `variant` |
+| `feature_flag.evaluation_error_total`    | Flag evaluation errors          | `{impression}` | `key`, `provider_name`                      |
+| `feature_flag.evaluation_active_count`   | Active flag evaluations counter | `{evaluation}` | `key`                                       |
+
+### 6. Experimental Status
+
+The hooks in the SDK are marked as **experimental** and may change in future versions. Monitor the [OpenFeature .NET SDK changelog](https://github.com/open-feature/dotnet-sdk/blob/main/CHANGELOG.md) for updates.
+
+### Benefits of Migration
+
+-   **Better Performance**: Native implementation with improved efficiency
+-   **Enhanced Metrics**: More detailed metrics with better dimensional data
+-   **Active Maintenance**: Regular updates and bug fixes in the main SDK
+-   **Latest OpenTelemetry Standards**: Compliance with the latest semantic conventions
+-   **Reduced Dependencies**: One less package to manage
+
+## Requirements (Deprecated Library)
+
+-   open-feature/dotnet-sdk v1.5.0 > v2.0.0
+
+> **Note**: For new implementations, use OpenFeature .NET SDK v2.7.0+ with native hooks instead.
+
+## Usage - Traces (Deprecated)
+
+> **⚠️ DEPRECATED**: Use `TraceEnricherHook` from `OpenFeature.Hooks` namespace in the main SDK instead.
 
 For this hook to function correctly a global `TracerProvider` must be set, an example of how to do this can be found below.
 
 The `open telemetry hook` taps into the after and error methods of the hook lifecycle to write `events` and `attributes` to an existing `span`.
 For this, an active span must be set in the `Tracer`, otherwise the hook will no-op.
 
-### Example
+### Example (Deprecated)
+
+> **⚠️ DEPRECATED**: This example uses the deprecated contrib library. See the migration guide above for the new approach.
 
 The following example demonstrates the use of the `OpenTelemetry hook` with the `OpenFeature dotnet-sdk`. The traces are sent to a `jaeger` OTLP collector running at `localhost:4317`.
 
@@ -65,7 +159,9 @@ In case something went wrong during a feature flag evaluation, you will see an e
 
 ![](./assets/otlp-error.png)
 
-## Usage - Metrics
+## Usage - Metrics (Deprecated)
+
+> **⚠️ DEPRECATED**: Use `MetricsHook` from `OpenFeature.Hooks` namespace in the main SDK instead.
 
 For this hook to function correctly a global `MeterProvider` must be set.
 `MetricsHook` performs metric collection by tapping into various hook stages.
@@ -81,7 +177,9 @@ Below are the metrics extracted by this hook and dimensions they carry:
 
 Consider the following code example for usage.
 
-### Example
+### Example (Deprecated)
+
+> **⚠️ DEPRECATED**: This example uses the deprecated contrib library. See the migration guide above for the new approach.
 
 The following example demonstrates the use of the `OpenTelemetry hook` with the `OpenFeature dotnet-sdk`. The metrics are sent to the `console`.
 
@@ -124,6 +222,48 @@ namespace OpenFeatureTestApp
 ```
 
 After running this example, you should be able to see some metrics being generated into the console.
+
+### Modern Metrics Example (SDK v2.7.0+)
+
+Here's how to achieve the same functionality using the native `MetricsHook` in the OpenFeature SDK:
+
+```csharp
+using OpenFeature.Contrib.Providers.Flagd;
+using OpenFeature;
+using OpenFeature.Hooks; // Use the native SDK hooks
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+
+namespace OpenFeatureTestApp
+{
+    class Hello {
+        static void Main(string[] args) {
+
+            // set up the OpenTelemetry OTLP exporter
+            var meterProvider = Sdk.CreateMeterProviderBuilder()
+                    .AddMeter("OpenFeature") // Note: different meter name for SDK
+                    .ConfigureResource(r => r.AddService("openfeature-test"))
+                    .AddConsoleExporter()
+                    .Build();
+
+            // add the native SDK MetricsHook to the OpenFeature instance
+            OpenFeature.Api.Instance.AddHooks(new MetricsHook());
+
+            var flagdProvider = new FlagdProvider(new Uri("http://localhost:8013"));
+
+            // Set the flagdProvider as the provider for the OpenFeature SDK
+            OpenFeature.Api.Instance.SetProvider(flagdProvider);
+
+            var client = OpenFeature.Api.Instance.GetClient("my-app");
+
+            var val = client.GetBooleanValueAsync("myBoolFlag", false, null);
+
+            // Print the value of the 'myBoolFlag' feature flag
+            System.Console.WriteLine(val.Result.ToString());
+        }
+    }
+}
+```
 
 ## License
 

--- a/src/OpenFeature.Contrib.Hooks.Otel/README.md
+++ b/src/OpenFeature.Contrib.Hooks.Otel/README.md
@@ -4,7 +4,7 @@
 
 ## Migration Guide
 
-As of OpenFeature .NET SDK version 2.7.0, OpenTelemetry hooks are now included natively in the SDK and this contrib library is no longer needed. Follow these steps to migrate:
+As of OpenFeature .NET SDK version 2.7.0, OpenTelemetry hooks are now included natively in the SDK and this contrib library is no longer needed. The native hooks have also been updated to match the latest version of the OpenTelemetry semantic conventions. Follow these steps to migrate:
 
 ### 1. Update Dependencies
 


### PR DESCRIPTION
Signed-off-by: André Silva <2493377+askpt@users.noreply.github.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request deprecates the `OpenFeature.Contrib.Hooks.Otel` library and introduces a migration guide to transition to the native OpenTelemetry hooks included in the OpenFeature .NET SDK starting with version 2.7.0. It also updates the `README.md` file to reflect the deprecation and provides detailed steps for migration and usage of the new hooks.

### Deprecation and Migration Updates:
* [`src/OpenFeature.Contrib.Hooks.Otel/README.md`](diffhunk://#diff-c8546049ce6f5bf0f9a5268959b3f2db5b6300b0e7a43ecb4efcb23cbf28115cL3-R108): Marked the library as deprecated and added a detailed migration guide, including steps to update dependencies, using statements, hook class names, and code examples to transition to the native OpenTelemetry hooks in the OpenFeature SDK.

### Project File Updates:
* [`src/OpenFeature.Contrib.Hooks.Otel/OpenFeature.Contrib.Hooks.Otel.csproj`](diffhunk://#diff-da565af3082a889c871e8431633817c9fbb23fd6401779cb0ff6c762b843d814R12-R23): Updated the project file to include `README.md` in the package metadata and ensure it is packed with the NuGet package.

### Documentation Enhancements:
* [`src/OpenFeature.Contrib.Hooks.Otel/README.md`](diffhunk://#diff-c8546049ce6f5bf0f9a5268959b3f2db5b6300b0e7a43ecb4efcb23cbf28115cL68-R164): Updated deprecated sections for "Usage - Traces" and "Usage - Metrics" with clear deprecation warnings and added modern examples using the native hooks from OpenFeature SDK v2.7.0+. [[1]](diffhunk://#diff-c8546049ce6f5bf0f9a5268959b3f2db5b6300b0e7a43ecb4efcb23cbf28115cL68-R164) [[2]](diffhunk://#diff-c8546049ce6f5bf0f9a5268959b3f2db5b6300b0e7a43ecb4efcb23cbf28115cL84-R182) [[3]](diffhunk://#diff-c8546049ce6f5bf0f9a5268959b3f2db5b6300b0e7a43ecb4efcb23cbf28115cR226-R267)

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Related to [#175](https://github.com/open-feature/dotnet-sdk/issues/175)

### Follow-up Tasks
- Add a deprecation notice to the nuget.org website