### PR TITLE
docs: Ensure README.md is included as PackageReadmeFile in project configuration

### DIFF
--- a/src/OpenFeature.Providers.Ofrep/OpenFeature.Providers.Ofrep.csproj
+++ b/src/OpenFeature.Providers.Ofrep/OpenFeature.Providers.Ofrep.csproj
@@ -8,6 +8,7 @@
     <FileVersion>$(VersionNumber)</FileVersion>
     <Description>OFREP provider for .NET</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Signed-off-by: André Silva <2493377+askpt@users.noreply.github.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request includes a minor update to the `OpenFeature.Providers.Ofrep` project file. The change specifies a `README.md` file to be included as the package's readme when published.

* [`src/OpenFeature.Providers.Ofrep/OpenFeature.Providers.Ofrep.csproj`](diffhunk://#diff-004af46220f914bdb2ad8fbbaa22391cd304171f62a52d551e6c93567c0ed39bR11): Added the `<PackageReadmeFile>` property to include `README.md` as the package readme.