### PR TITLE
ci: change nuget publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
     environment: publish
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
+      id-token: write # enable GitHub OIDC token issuance for this job (NuGet login)
       contents: write # upload sbom to a release
       attestations: write
       packages: read # for internal nuget reading
@@ -72,9 +72,16 @@ jobs:
         run: |
           dotnet pack --configuration Release --no-build
 
+        # Get a short-lived NuGet API key
+      - name: NuGet login (OIDC → temp API key)
+        uses: NuGet/login@76cce0bd8d4b2f5dcdb45e2316d76c328632a902 # v1
+        id: login
+        with:
+          user: ${{secrets.NUGET_USER}}
+
       - name: Publish to Nuget
         run: |
-          dotnet nuget push "${{ matrix.release }}/**/*.nupkg" --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_TOKEN }}
+          dotnet nuget push "${{ matrix.release }}/**/*.nupkg" --source https://api.nuget.org/v3/index.json --api-key "${{ steps.login.outputs.NUGET_API_KEY }}"
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0


### PR DESCRIPTION
Signed-off-by: André Silva <2493377+askpt@users.noreply.github.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request updates the NuGet publishing workflow in `.github/workflows/release.yml` to improve security and automation. The main change is switching from a static NuGet API key to using GitHub OIDC-based authentication to obtain a short-lived API key for publishing packages.

**NuGet publishing workflow improvements:**

* Added a step to log in to NuGet using GitHub OIDC and generate a temporary API key for publishing (`NuGet/login` action).
* Updated the NuGet publish step to use the temporary API key from the login step instead of a static secret.
* Clarified the `id-token: write` permission with a comment explaining its purpose for OIDC token issuance.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #467