### PR TITLE
docs: update copyright year and owner in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2025 OpenFeature Maintainers
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Signed-off-by: André Silva <2493377+askpt@users.noreply.github.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request updates the copyright information in the `LICENSE` file to reflect the current year and the correct copyright holders.

- Legal/metadata update:
  * Updated the copyright notice in the `LICENSE` file to "Copyright 2025 OpenFeature Maintainers" to reflect the current year and ownership.