### PR TITLE
ci: update SDK version and rollForward policy in global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
-    "sdk": {
-        "rollForward": "latestFeature",
-        "version": "9.0.203",
-        "allowPrerelease": false
-    }
+  "sdk": {
+    "rollForward": "disable",
+    "version": "9.0.306",
+    "allowPrerelease": false
+  }
 }


### PR DESCRIPTION
Signed-off-by: André Silva <2493377+askpt@users.noreply.github.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request updates the .NET SDK configuration in the `global.json` file. The SDK version is updated, and the roll-forward behavior is changed to prevent automatic upgrades to newer feature versions.

SDK configuration updates:

* Changed the SDK `version` from `9.0.203` to `9.0.306` and set `rollForward` to `"disable"` to ensure builds use the exact specified SDK version.

### Notes
<!-- any additional notes for this PR -->

This is a known issue: https://github.com/dotnet/msbuild/issues/12751