### PR TITLE
test: skip failing test for configuration ignoring based on etag and last-modified

### DIFF
--- a/test/OpenFeature.Providers.GOFeatureFlag.Test/GoFeatureFlagProviderTest.cs
+++ b/test/OpenFeature.Providers.GOFeatureFlag.Test/GoFeatureFlagProviderTest.cs
@@ -477,7 +477,7 @@ public class GOFeatureFlagProviderTest
             Assert.True(handlerCalled);
         }
 
-        [Fact(DisplayName = "Should ignore configuration if etag is different by last-modified is older")]
+        [Fact(DisplayName = "Should ignore configuration if etag is different by last-modified is older", Skip = "This test is failing. See https://github.com/open-feature/dotnet-sdk-contrib/issues/506")]
         public async Task ShouldIgnoreConfigurationIfEtagIsDifferentByLastModifiedIsOlder()
         {
             var mockHttp = new RelayProxyMock();


### PR DESCRIPTION
Signed-off-by: André Silva <2493377+askpt@users.noreply.github.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request makes a minor test update by temporarily skipping a failing test in the `GoFeatureFlagProviderTest.cs` file. The test is now annotated with a skip reason referencing a related GitHub issue for further investigation.

- Testing:
  * The `[Fact]` attribute for the `ShouldIgnoreConfigurationIfEtagIsDifferentByLastModifiedIsOlder` test now includes `Skip` with a reference to issue #506, indicating the test is failing and should be ignored until resolved.