### PR TITLE
ci: rollback SDK version to 9.0.203 and enable latest feature roll forward

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "rollForward": "disable",
-    "version": "9.0.306",
+    "rollForward": "latestFeature",
+    "version": "9.0.203",
     "allowPrerelease": false
   }
 }


### PR DESCRIPTION
Signed-off-by: André Silva <2493377+askpt@users.noreply.github.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request updates the .NET SDK settings in `global.json` to use a slightly earlier version and to allow rolling forward to the latest feature version. This change ensures better compatibility with different environments and allows the project to take advantage of new feature releases.

SDK configuration updates:

* Changed `sdk.version` from `9.0.306` to `9.0.203` and updated `rollForward` from `"disable"` to `"latestFeature"` in `global.json` to improve compatibility and allow newer feature versions of the .NET SDK.