### PR TITLE
fix: Fix Flagd InProcess Evaluator when no defaultVariant is specified

### DIFF
--- a/src/OpenFeature.Contrib.Providers.Flagd/Resolver/InProcess/JsonEvaluator.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/Resolver/InProcess/JsonEvaluator.cs
@@ -285,7 +285,7 @@ internal class JsonEvaluator
             }
 
             // using the returned variant, go through the available variants and take the correct value if it exists
-            if (variant == null)
+            if (string.IsNullOrEmpty(variant))
             {
                 if (string.IsNullOrEmpty(flagConfiguration.DefaultVariant))
                 {


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Found this while updating the E2E tests for the Flagd provider. If the flag does not have a `defaultVariant` specified or it is an empty string, we should return the FlagNotFound reason and return code default.

See Flagd gherkin tests for this particular case here: https://github.com/open-feature/flagd-testbed/blob/b62f5dbe860ecf4f36ec757dfdc0b38f7b3dec6e/gherkin/evaluation.feature#L68-L86

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

