### PR TITLE
test: Skip failing evaluation details test

### DIFF
--- a/test/OpenFeature.Providers.GOFeatureFlag.Test/GoFeatureFlagProviderTest.cs
+++ b/test/OpenFeature.Providers.GOFeatureFlag.Test/GoFeatureFlagProviderTest.cs
@@ -371,7 +371,8 @@ public class GOFeatureFlagProviderTest
             Assert.True(handlerCalled);
         }
 
-        [Fact(DisplayName = "Should change evaluation details if config has changed")]
+        [Fact(DisplayName = "Should change evaluation details if config has changed",
+            Skip = "This test is failing. See https://github.com/open-feature/dotnet-sdk-contrib/issues/506")]
         public async Task ShouldChangeEvaluationDetailsIfConfigHasChanged()
         {
             var mockHttp = new RelayProxyMock();


### PR DESCRIPTION
Signed-off-by: André Silva <2493377+askpt@users.noreply.github.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request makes a small change to the test suite by temporarily disabling a failing test. The test `ShouldChangeEvaluationDetailsIfConfigHasChanged` in `GoFeatureFlagProviderTest.cs` is now skipped, with a note referencing the related GitHub issue for tracking.

- Testing:
  * Temporarily skipped the `ShouldChangeEvaluationDetailsIfConfigHasChanged` test in `GoFeatureFlagProviderTest.cs` due to failures, referencing issue #506 for follow-up.