### PR TITLE
fix(flagd): Throw general error when targeting variant not found

### DIFF
--- a/src/OpenFeature.Contrib.Providers.Flagd/Resolver/InProcess/JsonEvaluator.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagd/Resolver/InProcess/JsonEvaluator.cs
@@ -366,7 +366,7 @@ internal class JsonEvaluator
             else
             {
                 throw new FeatureProviderException(ErrorType.General,
-                    "TARGETING_MATCH_ERROR: flag '" + flagKey + "' targeting resolved to variant.");
+                    $"TARGETING_MATCH_ERROR: flag '{flagKey}' targeting resolved to variant '{variant}', but it could not be found.");
             }
         }
 

--- a/test/OpenFeature.Contrib.Providers.Flagd.Test/JsonEvaluatorTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagd.Test/JsonEvaluatorTest.cs
@@ -490,6 +490,6 @@ public class UnitTestJsonEvaluator
         var ex = Assert.Throws<FeatureProviderException>(() => this._jsonEvaluator.ResolveIntegerValueAsync("missing-variant-targeting-flag", 3, context));
 
         Assert.Equal(ErrorType.General, ex.ErrorType);
-        Assert.Equal("TARGETING_MATCH_ERROR: flag 'missing-variant-targeting-flag' targeting resolved to variant.", ex.Message);
+        Assert.Equal("TARGETING_MATCH_ERROR: flag 'missing-variant-targeting-flag' targeting resolved to variant 'three', but it could not be found.", ex.Message);
     }
 }


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Updates the JsonEvaluator for the InProcess resolver to return a general error when the targeting variant is not found. This is defined behaviour in the [targeting.feature](https://github.com/open-feature/flagd-testbed/blob/6515f91a2afcd53563e7adfc40285e9f662e9def/gherkin/targeting.feature#L145). Also used this as an opportunity to add an extra check for the type of error and message being returned in the previous test case.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

