### PR TITLE
chore: bump WASM to v0.1.3

### DIFF
--- a/src/OpenFeature.Providers.GOFeatureFlag/OpenFeature.Providers.GOFeatureFlag.csproj
+++ b/src/OpenFeature.Providers.GOFeatureFlag/OpenFeature.Providers.GOFeatureFlag.csproj
@@ -10,7 +10,7 @@
     <Authors>Thomas Poignant</Authors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <WasmVersion>v1.45.0</WasmVersion>
+    <WasmVersion>v0.1.3</WasmVersion>
     <OutputDirectory>$(ProjectDir)WasmModules</OutputDirectory>
     <SourceFile>$(ProjectDir)wasm-releases/evaluation/gofeatureflag-evaluation_$(WasmVersion).wasi</SourceFile>
     <DestinationFile>$(OutputDirectory)\gofeatureflag-evaluation.wasi</DestinationFile>


### PR DESCRIPTION
Automated pull request to bump the GO Feature Flag evaluation WASM version to v0.1.3.