### PR TITLE
ci: Update to attest action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
           dotnet nuget push "${{ matrix.release }}/**/*.nupkg" --source https://api.nuget.org/v3/index.json --api-key "${{ steps.login.outputs.NUGET_API_KEY }}"
 
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: "${{ matrix.release }}/**/*.nupkg"
 
@@ -101,7 +101,7 @@ jobs:
           json: true
           github-bearer-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Attest package
+      - name: Attest SBOM package
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: "${{ matrix.release }}/**/*.nupkg"


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request updates the artifact attestation steps in the release workflow to use newer versions of the `actions/attest` GitHub Action, consolidating attestation and SBOM generation under a single, updated action. This improves maintainability and ensures the workflow uses the latest security features.

**Workflow action updates:**

* Updated the artifact attestation step to use `actions/attest@v4.1.0` instead of `actions/attest-build-provenance@v3.2.0` in `.github/workflows/release.yml`.
* Replaced the SBOM attestation step from `actions/attest-sbom@v3.0.0` to `actions/attest@v4.1.0` and renamed the step for clarity in `.github/workflows/release.yml`.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #599