### PR TITLE
chore(deps): Upgrade sticky-pull-request-comment to v3.0.4

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: marocchino/sticky-pull-request-comment@70d2764d1a7d5d9560b100cbea0077fc8f633987 # v3
+      - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         # When the previous steps fails, the workflow would stop. By adding this
         # condition you can continue the execution with the populated error message.
         if: always() && (steps.lint_pr_title.outputs.error_message != null)
@@ -37,7 +37,7 @@ jobs:
             ```
       # Delete a previous comment when the issue has been resolved
       - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
-        uses: marocchino/sticky-pull-request-comment@70d2764d1a7d5d9560b100cbea0077fc8f633987 # v3
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: pr-title-lint-error
           delete: true


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->
This pull request updates the version of the `marocchino/sticky-pull-request-comment` GitHub Action used in the `lint-pr.yml` workflow to a newer release. This ensures improved reliability and potentially includes bug fixes or new features from the updated action.

**Workflow dependency update:**

* Updated `marocchino/sticky-pull-request-comment` action from commit `70d2764d1a7d5d9560b100cbea0077fc8f633987` (v3) to `0ea0beb66eb9baf113663a64ec522f60e49231c0` (v3.0.4) in all relevant workflow steps in `.github/workflows/lint-pr.yml`. [[1]](diffhunk://#diff-70c3a017bfdb629fd50281fe5f7ad22e29c0ddac36e7065e9dc6d4f0924104f4L22-R22) [[2]](diffhunk://#diff-70c3a017bfdb629fd50281fe5f7ad22e29c0ddac36e7065e9dc6d4f0924104f4L39-R39)

### Notes
<!-- any additional notes for this PR -->

This fixes the renovate warning we are getting in this repository.
