### PR TITLE
fix: various custom operator conformance fixes

### DIFF
--- a/src/OpenFeature.Providers.Flagd/OpenFeature.Providers.Flagd.csproj
+++ b/src/OpenFeature.Providers.Flagd/OpenFeature.Providers.Flagd.csproj
@@ -37,7 +37,7 @@
     <!-- The schema.proto file referenced here will be used to automatically generate the Grpc
     client when executing 'dotnet build' -->
     <!-- The generated files will be placed in ./obj/Debug/netstandard2.0/Protos -->
-    <PackageReference Include="JsonLogic" Version="5.4.0" />
+    <PackageReference Include="JsonLogic" Version="[6.0.2]" />
     <PackageReference Include="murmurhash" Version="1.0.3" />
     <PackageReference Include="NJsonSchema" Version="11.0.0" />
     <PackageReference Include="Semver" Version="3.0.0" />

--- a/src/OpenFeature.Providers.Flagd/Resolver/InProcess/CustomEvaluators/FractionalRule.cs
+++ b/src/OpenFeature.Providers.Flagd/Resolver/InProcess/CustomEvaluators/FractionalRule.cs
@@ -42,6 +42,10 @@ internal sealed class FractionalEvaluator : IRule
         }
         else
         {
+            if (string.IsNullOrEmpty(flagdProperties.TargetingKey))
+            {
+                return null;
+            }
             propertyValue = flagdProperties.FlagKey + flagdProperties.TargetingKey;
         }
 

--- a/src/OpenFeature.Providers.Flagd/Resolver/InProcess/CustomEvaluators/FractionalRule.cs
+++ b/src/OpenFeature.Providers.Flagd/Resolver/InProcess/CustomEvaluators/FractionalRule.cs
@@ -42,7 +42,7 @@ internal sealed class FractionalEvaluator : IRule
         }
         else
         {
-            if (string.IsNullOrEmpty(flagdProperties.TargetingKey))
+            if (string.IsNullOrWhiteSpace(flagdProperties.TargetingKey))
             {
                 return null;
             }

--- a/src/OpenFeature.Providers.Flagd/Resolver/InProcess/CustomEvaluators/SemVerRule.cs
+++ b/src/OpenFeature.Providers.Flagd/Resolver/InProcess/CustomEvaluators/SemVerRule.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.Json.Nodes;
 using Json.Logic;
 using Semver;
@@ -16,6 +17,10 @@ internal sealed class SemVerRule : IRule
     const string OperatorMatchMajor = "^";
     const string OperatorMatchMinor = "~";
 
+    // allow v/V prefix and partial versions (e.g. "1", "1.0")
+    private const SemVersionStyles LenientStyles =
+        SemVersionStyles.AllowV
+        | SemVersionStyles.OptionalMinorPatch;
 
     /// <inheritdoc/>
     public JsonNode Apply(JsonNode args, EvaluationContext context)
@@ -23,44 +28,59 @@ internal sealed class SemVerRule : IRule
         // check if we have at least 3 arguments
         if (args.AsArray().Count < 3)
         {
-            return false;
+            return null;
         }
-        // get the value from the provided evaluation context
-        var versionString = JsonLogic.Apply(args[0], context).ToString();
 
-        // get the operator
-        var semVerOperator = JsonLogic.Apply(args[1], context).ToString();
+        var rawVersion = Convert.ToString(JsonLogic.Apply(args[0], context));
+        var semVerOperator = Convert.ToString(JsonLogic.Apply(args[1], context));
+        var rawTargetVersion = Convert.ToString(JsonLogic.Apply(args[2], context));
 
-        // get the target version
-        var targetVersionString = JsonLogic.Apply(args[2], context).ToString();
+        var version = NormalizeVersion(rawVersion);
+        var targetVersion = NormalizeVersion(rawTargetVersion);
 
-        //convert to semantic versions
-        if (!SemVersion.TryParse(versionString, SemVersionStyles.Strict, out var version) ||
-            !SemVersion.TryParse(targetVersionString, SemVersionStyles.Strict, out var targetVersion))
+        if (version == null || targetVersion == null)
         {
-            return false;
+            return null;
         }
 
         switch (semVerOperator)
         {
             case OperatorEqual:
-                return version.CompareSortOrderTo(targetVersion) == 0;
+                return version.ComparePrecedenceTo(targetVersion) == 0;
             case OperatorNotEqual:
-                return version.CompareSortOrderTo(targetVersion) != 0;
+                return version.ComparePrecedenceTo(targetVersion) != 0;
             case OperatorLess:
-                return version.CompareSortOrderTo(targetVersion) < 0;
+                return version.ComparePrecedenceTo(targetVersion) < 0;
             case OperatorLessOrEqual:
-                return version.CompareSortOrderTo(targetVersion) <= 0;
+                return version.ComparePrecedenceTo(targetVersion) <= 0;
             case OperatorGreater:
-                return version.CompareSortOrderTo(targetVersion) > 0;
+                return version.ComparePrecedenceTo(targetVersion) > 0;
             case OperatorGreaterOrEqual:
-                return version.CompareSortOrderTo(targetVersion) >= 0;
+                return version.ComparePrecedenceTo(targetVersion) >= 0;
             case OperatorMatchMajor:
                 return version.Major == targetVersion.Major;
             case OperatorMatchMinor:
                 return version.Major == targetVersion.Major && version.Minor == targetVersion.Minor;
             default:
-                return false;
+                return null;
         }
+    }
+
+    /// <summary>
+    /// Normalize a version string: coerce numeric inputs to string, allow v/V prefix and partial versions, but reject truly invalid input.
+    /// </summary>
+    private static SemVersion NormalizeVersion(string raw)
+    {
+        if (string.IsNullOrEmpty(raw))
+        {
+            return null;
+        }
+
+        if (SemVersion.TryParse(raw, LenientStyles, out var version))
+        {
+            return version;
+        }
+
+        return null;
     }
 }

--- a/src/OpenFeature.Providers.Flagd/Resolver/InProcess/CustomEvaluators/StringRule.cs
+++ b/src/OpenFeature.Providers.Flagd/Resolver/InProcess/CustomEvaluators/StringRule.cs
@@ -11,7 +11,7 @@ internal sealed class StartsWithRule : IRule
     {
         if (!StringRule.isValid(args, context, out string operandA, out string operandB))
         {
-            return false;
+            return null;
         }
         return Convert.ToString(operandA).StartsWith(Convert.ToString(operandB));
     }
@@ -23,7 +23,7 @@ internal sealed class EndsWithRule : IRule
     {
         if (!StringRule.isValid(args, context, out string operandA, out string operandB))
         {
-            return false;
+            return null;
         }
         return operandA.EndsWith(operandB);
     }

--- a/src/OpenFeature.Providers.Flagd/Resolver/InProcess/CustomEvaluators/UnresolvedRefRule.cs
+++ b/src/OpenFeature.Providers.Flagd/Resolver/InProcess/CustomEvaluators/UnresolvedRefRule.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Text.Json.Nodes;
+using Json.Logic;
+
+namespace OpenFeature.Providers.Flagd.Resolver.InProcess.CustomEvaluators;
+
+/// <summary>
+/// Catch-all rule for unresolved $ref references.
+/// If a $ref was not replaced during the evaluator transform step, this rule throws so the caller gets a PARSE_ERROR.
+/// This behavior is consistent with other implementations (though the mechanism differs).
+/// </summary>
+internal sealed class UnresolvedRefRule : IRule
+{
+    public JsonNode Apply(JsonNode args, EvaluationContext context)
+    {
+        var evaluatorName = args?.ToString() ?? "unknown";
+        throw new InvalidOperationException(
+            $"Unresolved $ref: evaluator '{evaluatorName}' was not found.");
+    }
+}

--- a/src/OpenFeature.Providers.Flagd/Resolver/InProcess/CustomEvaluators/UnresolvedRefRule.cs
+++ b/src/OpenFeature.Providers.Flagd/Resolver/InProcess/CustomEvaluators/UnresolvedRefRule.cs
@@ -11,9 +11,11 @@ namespace OpenFeature.Providers.Flagd.Resolver.InProcess.CustomEvaluators;
 /// </summary>
 internal sealed class UnresolvedRefRule : IRule
 {
+    private const string UnknownEvaluator = "unknown";
+
     public JsonNode Apply(JsonNode args, EvaluationContext context)
     {
-        var evaluatorName = args?.ToString() ?? "unknown";
+        var evaluatorName = args?.ToString() ?? UnknownEvaluator;
         throw new InvalidOperationException(
             $"Unresolved $ref: evaluator '{evaluatorName}' was not found.");
     }

--- a/src/OpenFeature.Providers.Flagd/Resolver/InProcess/JsonEvaluator.cs
+++ b/src/OpenFeature.Providers.Flagd/Resolver/InProcess/JsonEvaluator.cs
@@ -79,12 +79,14 @@ internal class JsonEvaluator
         // replace evaluators
         if (parsed.Evaluators != null && parsed.Evaluators.Count > 0)
         {
-            parsed.Evaluators.Keys.ToList().ForEach(key =>
+            foreach (var key in parsed.Evaluators.Keys)
             {
                 var val = parsed.Evaluators[key];
-                var evaluatorRegex = new Regex("{\"\\$ref\"\\s*:\\s*\"" + key + "\"}");
-                transformed = evaluatorRegex.Replace(transformed, Convert.ToString(val));
-            });
+                var escapedKey = Regex.Escape(key);
+                var evaluatorRegex = new Regex("{\"\\$ref\"\\s*:\\s*\"" + escapedKey + "\"}");
+                var serializedVal = JsonSerializer.Serialize(val);
+                transformed = evaluatorRegex.Replace(transformed, new MatchEvaluator(_ => serializedVal));
+            }
         }
 
         var data = JsonSerializer.Deserialize<FlagSyncData>(transformed);

--- a/src/OpenFeature.Providers.Flagd/Resolver/InProcess/JsonEvaluator.cs
+++ b/src/OpenFeature.Providers.Flagd/Resolver/InProcess/JsonEvaluator.cs
@@ -83,7 +83,7 @@ internal class JsonEvaluator
             {
                 var val = parsed.Evaluators[key];
                 var escapedKey = Regex.Escape(key);
-                var evaluatorRegex = new Regex("{\"\\$ref\"\\s*:\\s*\"" + escapedKey + "\"}");
+                var evaluatorRegex = new Regex("{\"\\$ref\"\\s*:\\s*\"" + escapedKey + "\"}", RegexOptions.Compiled);
                 var serializedVal = JsonSerializer.Serialize(val);
                 transformed = evaluatorRegex.Replace(transformed, new MatchEvaluator(_ => serializedVal));
             }

--- a/src/OpenFeature.Providers.Flagd/Resolver/InProcess/JsonEvaluator.cs
+++ b/src/OpenFeature.Providers.Flagd/Resolver/InProcess/JsonEvaluator.cs
@@ -67,6 +67,7 @@ internal class JsonEvaluator
         RuleRegistry.AddRule("ends_with", new EndsWithRule());
         RuleRegistry.AddRule("sem_ver", new SemVerRule());
         RuleRegistry.AddRule("fractional", new FractionalEvaluator());
+        RuleRegistry.AddRule("$ref", new UnresolvedRefRule());
     }
 
     internal FlagSyncData Parse(string flagConfigurations)
@@ -81,7 +82,7 @@ internal class JsonEvaluator
             parsed.Evaluators.Keys.ToList().ForEach(key =>
             {
                 var val = parsed.Evaluators[key];
-                var evaluatorRegex = new Regex("{\"\\$ref\":\"" + key + "\"}");
+                var evaluatorRegex = new Regex("{\"\\$ref\"\\s*:\\s*\"" + key + "\"}");
                 transformed = evaluatorRegex.Replace(transformed, Convert.ToString(val));
             });
         }

--- a/test/OpenFeature.Providers.Flagd.E2e.Common/Steps/ContextSteps.cs
+++ b/test/OpenFeature.Providers.Flagd.E2e.Common/Steps/ContextSteps.cs
@@ -27,6 +27,10 @@ public class ContextSteps
                 this._state.EvaluationContextBuilder.Set(key, new Value(long.Parse(value)));
                 break;
 
+            case "Float":
+                this._state.EvaluationContextBuilder.Set(key, new Value(double.Parse(value)));
+                break;
+
             default:
                 break;
         }

--- a/test/OpenFeature.Providers.Flagd.E2e.ProcessTest/BeforeHooks.cs
+++ b/test/OpenFeature.Providers.Flagd.E2e.ProcessTest/BeforeHooks.cs
@@ -27,6 +27,5 @@ public class BeforeHooks
         Skip.If(tags.Contains("sync-port"), "Skipping sync-port as it is not supported.");
         Skip.If(!tags.Contains("in-process"), "Skipping scenario because it does not have required tag.");
         Skip.If(tags.Contains("fractional-v1"), "Skipping legacy fractional bucketing test; v2 algorithm is implemented.");
-        Skip.If(tags.Contains("operator-errors"), "Skipping operator-errors test; flagd server does not yet fall back to default on operator errors.");
     }
 }

--- a/test/OpenFeature.Providers.Flagd.E2e.RpcTest/BeforeHooks.cs
+++ b/test/OpenFeature.Providers.Flagd.E2e.RpcTest/BeforeHooks.cs
@@ -27,5 +27,9 @@ public class BeforeHooks
         Skip.If(!tags.Contains("rpc"), "Skipping scenario because it does not have required tag.");
         Skip.If(tags.Contains("fractional-v1"), "Skipping legacy fractional bucketing test; v2 algorithm is implemented.");
         Skip.If(tags.Contains("operator-errors"), "Skipping operator-errors test; flagd server does not yet fall back to default on operator errors.");
+        Skip.If(tags.Contains("semver-edge-cases"), "Skipping semver-edge-cases; flagd server not updated.");
+        Skip.If(tags.Contains("evaluator-refs-whitespace"), "Skipping evaluator-refs-whitespace; flagd server not updated.");
+        Skip.If(tags.Contains("non-existent-evaluator-ref"), "Skipping non-existent-evaluator-ref; flagd server not updated.");
+        Skip.If(tags.Contains("fractional-single-entry"), "Skipping fractional-single-entry; flagd server not updated.");
     }
 }

--- a/test/OpenFeature.Providers.Flagd.E2e.RpcTest/BeforeHooks.cs
+++ b/test/OpenFeature.Providers.Flagd.E2e.RpcTest/BeforeHooks.cs
@@ -26,10 +26,5 @@ public class BeforeHooks
         var tags = new HashSet<string>(scenarioTags.Concat(featureTags));
         Skip.If(!tags.Contains("rpc"), "Skipping scenario because it does not have required tag.");
         Skip.If(tags.Contains("fractional-v1"), "Skipping legacy fractional bucketing test; v2 algorithm is implemented.");
-        Skip.If(tags.Contains("operator-errors"), "Skipping operator-errors test; flagd server does not yet fall back to default on operator errors.");
-        Skip.If(tags.Contains("semver-edge-cases"), "Skipping semver-edge-cases; flagd server not updated.");
-        Skip.If(tags.Contains("evaluator-refs-whitespace"), "Skipping evaluator-refs-whitespace; flagd server not updated.");
-        Skip.If(tags.Contains("non-existent-evaluator-ref"), "Skipping non-existent-evaluator-ref; flagd server not updated.");
-        Skip.If(tags.Contains("fractional-single-entry"), "Skipping fractional-single-entry; flagd server not updated.");
     }
 }

--- a/test/OpenFeature.Providers.Flagd.Test/JsonEvaluatorTest.cs
+++ b/test/OpenFeature.Providers.Flagd.Test/JsonEvaluatorTest.cs
@@ -459,6 +459,42 @@ public class UnitTestJsonEvaluator
     }
 
     [Fact]
+    public void TestJsonEvaluatorStringValuedEvaluatorRef()
+    {
+        // verifies that string-valued $evaluators are serialized with quotes,
+        // producing valid JSON after $ref substitution
+        var flagConfig = //lang=json
+            """
+            {
+              "$evaluators": {
+                "colorEval": "red"
+              },
+              "flags": {
+                "string-evaluator-flag": {
+                  "state": "ENABLED",
+                  "variants": {
+                    "red": "#CC0000",
+                    "blue": "#0000CC"
+                  },
+                  "defaultVariant": "blue",
+                  "targeting": {
+                    "if": [true, { "$ref": "colorEval" }]
+                  }
+                }
+              }
+            }
+            """;
+
+        _jsonEvaluator.Sync(FlagConfigurationUpdateType.ALL, flagConfig);
+
+        var result = _jsonEvaluator.ResolveStringValueAsync("string-evaluator-flag", "");
+
+        Assert.Equal("#CC0000", result.Value);
+        Assert.Equal("red", result.Variant);
+        Assert.Equal(Reason.TargetingMatch, result.Reason);
+    }
+
+    [Fact]
     public void TestJsonEvaluatorFlagWithMissingVariantReturnsGeneralError()
     {
         // Arrange

--- a/test/OpenFeature.Providers.Flagd.Test/SemVerEvaluatorTest.cs
+++ b/test/OpenFeature.Providers.Flagd.Test/SemVerEvaluatorTest.cs
@@ -301,7 +301,7 @@ public class SemVerEvaluatorTest
 
         // Act & Assert
         var result = JsonLogic.Apply(rule, data);
-        Assert.False(result.GetValue<bool>());
+        Assert.Null(result);
     }
 
     [Fact]
@@ -325,6 +325,6 @@ public class SemVerEvaluatorTest
 
         // Act & Assert
         var result = JsonLogic.Apply(rule, data);
-        Assert.False(result.GetValue<bool>());
+        Assert.Null(result);
     }
 }

--- a/test/OpenFeature.Providers.Flagd.Test/StringEvaluatorTest.cs
+++ b/test/OpenFeature.Providers.Flagd.Test/StringEvaluatorTest.cs
@@ -91,7 +91,7 @@ public class StringEvaluatorTest
 
         // Act & Assert
         var result = JsonLogic.Apply(rule, data);
-        Assert.False(result.GetValue<bool>());
+        Assert.Null(result);
     }
 
     [Fact]
@@ -114,7 +114,7 @@ public class StringEvaluatorTest
 
         // Act & Assert
         var result = JsonLogic.Apply(rule, data);
-        Assert.False(result.GetValue<bool>());
+        Assert.Null(result);
     }
 
     [Fact]
@@ -136,7 +136,7 @@ public class StringEvaluatorTest
 
         // Act & Assert
         var result = JsonLogic.Apply(rule, data);
-        Assert.False(result.GetValue<bool>());
+        Assert.Null(result);
     }
 
     [Fact]
@@ -158,6 +158,6 @@ public class StringEvaluatorTest
 
         // Act & Assert
         var result = JsonLogic.Apply(rule, data);
-        Assert.False(result.GetValue<bool>());
+        Assert.Null(result);
     }
 }


### PR DESCRIPTION
fix: various custom operator conformance fixes

* support v/V prefix in semver
* support partial versions in semver
* ignore build metadata in semver comparison
* return null on errors
* handle unresolved $ref as evaluation error
* fix fractional with missing targetingKey

:warning: wait until flagd/RPC is updated to merge.

Fixes: https://github.com/open-feature/dotnet-sdk-contrib/issues/634

---

Related:
* https://github.com/open-feature/flagd/pull/1950
* https://github.com/open-feature/java-sdk-contrib/pull/1778
* https://github.com/open-feature/js-sdk-contrib/pull/1519
* https://github.com/open-feature/python-sdk-contrib/pull/386
* https://github.com/open-feature/go-sdk-contrib/pull/874