### PR TITLE
feat!: bump Flagsmith SDK to 8.x/9.x, drop IFlagsmithConfiguration

### DIFF
--- a/src/OpenFeature.Contrib.Providers.Flagsmith/FlagsmithProvider.cs
+++ b/src/OpenFeature.Contrib.Providers.Flagsmith/FlagsmithProvider.cs
@@ -33,8 +33,8 @@ public class FlagsmithProvider : FeatureProvider
     /// Creates new instance of <see cref="FlagsmithProvider"/>
     /// </summary>
     /// <param name="providerOptions">Open feature provider options. You can just use <see cref="FlagsmithProviderConfiguration"/> class </param>
-    /// <param name="flagsmithOptions">Flagsmith client options. You can just use <see cref="FlagsmithConfiguration"/> class</param>
-    public FlagsmithProvider(IFlagsmithProviderConfiguration providerOptions, IFlagsmithConfiguration flagsmithOptions)
+    /// <param name="flagsmithOptions">Flagsmith client options.</param>
+    public FlagsmithProvider(IFlagsmithProviderConfiguration providerOptions, FlagsmithConfiguration flagsmithOptions)
     {
         Configuration = providerOptions;
         _flagsmithClient = new FlagsmithClient(flagsmithOptions);
@@ -43,13 +43,14 @@ public class FlagsmithProvider : FeatureProvider
     /// <summary>
     /// Creates new instance of <see cref="FlagsmithProvider"/>
     /// </summary>
-    /// <param name="flagsmithOptions">Flagsmith client options. You can just use <see cref="FlagsmithConfiguration"/> class</param>
+    /// <param name="flagsmithOptions">Flagsmith client options.</param>
     /// <param name="providerOptions">Open feature provider options. You can just use <see cref="FlagsmithProviderConfiguration"/> class </param>
     /// <param name="httpClient">Http client that will be used for flagsmith requests. You also can use it to register <see cref="FeatureProvider"/> as Typed HttpClient with <see cref="FeatureProvider"> as abstraction</see></param>
-    public FlagsmithProvider(IFlagsmithProviderConfiguration providerOptions, IFlagsmithConfiguration flagsmithOptions, HttpClient httpClient)
+    public FlagsmithProvider(IFlagsmithProviderConfiguration providerOptions, FlagsmithConfiguration flagsmithOptions, HttpClient httpClient)
     {
         Configuration = providerOptions;
-        _flagsmithClient = new FlagsmithClient(flagsmithOptions, httpClient);
+        flagsmithOptions.HttpClient = httpClient;
+        _flagsmithClient = new FlagsmithClient(flagsmithOptions);
     }
 
 

--- a/src/OpenFeature.Contrib.Providers.Flagsmith/OpenFeature.Contrib.Providers.Flagsmith.csproj
+++ b/src/OpenFeature.Contrib.Providers.Flagsmith/OpenFeature.Contrib.Providers.Flagsmith.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Flagsmith" Version="5.4.3" />
+    <PackageReference Include="Flagsmith" Version="[8.0,10.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenFeature.Contrib.Providers.Flagsmith/README.md
+++ b/src/OpenFeature.Contrib.Providers.Flagsmith/README.md
@@ -57,10 +57,10 @@ var providerConfig = new FlagsmithProviderConfiguration();
 // Flagsmith client configuration
 var flagsmithConfig = new FlagsmithConfiguration
 {
-    ApiUrl = "https://edge.api.flagsmith.com/api/v1/",
+    ApiUri = new Uri("https://edge.api.flagsmith.com/api/v1/"),
     EnvironmentKey = "",
-    EnableClientSideEvaluation = false,
-    EnvironmentRefreshIntervalSeconds = 60,
+    EnableLocalEvaluation = false,
+    EnvironmentRefreshInterval = TimeSpan.FromSeconds(60),
     EnableAnalytics = false,
     Retries = 1,
 };

--- a/test/OpenFeature.Contrib.Providers.Flagsmith.Test/FlagsmithProviderTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagsmith.Test/FlagsmithProviderTest.cs
@@ -16,10 +16,10 @@ public class UnitTestFlagsmithProvider
 {
     private static FlagsmithConfiguration GetDefaultFlagsmithConfiguration() => new()
     {
-        ApiUrl = "https://edge.api.flagsmith.com/api/v1/",
+        ApiUri = new Uri("https://edge.api.flagsmith.com/api/v1/"),
         EnvironmentKey = "some-key",
-        EnableClientSideEvaluation = false,
-        EnvironmentRefreshIntervalSeconds = 60,
+        EnableLocalEvaluation = false,
+        EnvironmentRefreshInterval = TimeSpan.FromSeconds(60),
         EnableAnalytics = false,
         Retries = 1
     };

--- a/test/OpenFeature.Contrib.Providers.Flagsmith.Test/FlagsmithProviderTest.cs
+++ b/test/OpenFeature.Contrib.Providers.Flagsmith.Test/FlagsmithProviderTest.cs
@@ -48,12 +48,13 @@ public class UnitTestFlagsmithProvider
         var config = GetDefaultFlagsmithConfiguration();
         var providerConfig = GetDefaultFlagsmithProviderConfigurationConfiguration();
         using var httpClient = new HttpClient();
+
         // Act
         var flagsmithProvider = new FlagsmithProvider(providerConfig, config, httpClient);
 
-
         // Assert
         Assert.NotNull(flagsmithProvider._flagsmithClient);
+        Assert.Same(httpClient, config.HttpClient);
     }
 
     [Fact]


### PR DESCRIPTION
## This PR

- Fixes CS7069 build failure for consumers using `OpenFeature.Contrib.Providers.Flagsmith` with Flagsmith SDK 8.x or 9.x. The provider exposed `Flagsmith.IFlagsmithConfiguration` in two public constructor signatures; upstream removed that interface in 7.0, so any consumer referencing both packages fails to compile.
- Replaces `IFlagsmithConfiguration` parameter with concrete `FlagsmithConfiguration` in two `FlagsmithProvider` constructors.
- Routes `HttpClient` through `FlagsmithConfiguration.HttpClient`  the upstream `(config, HttpClient)` ctor was removed.
- Bumps `<PackageReference Include="Flagsmith">` from `5.4.3` to `[8.0,10.0)`.
- Updates test fixture and README example for renamed config properties.

### Related Issues

Fixes #643

### Notes

This is a breaking change (`feat!:`). The `IFlagsmithConfiguration` interface no longer appears in any provider public surface. Consumers passing the concrete `FlagsmithConfiguration` (per the README example) need no source change. Consumers that bound `IFlagsmithConfiguration` symbolically (e.g. for DI) will need to switch to the concrete class upstream removed the interface entirely, so there is no source compatible alternative.

Property renames in `FlagsmithConfiguration` that consumers will see (these happened upstream in 7.0; the test fixture and README example are updated to match):

- `ApiUrl` (string) → `ApiUri` (Uri)
- `EnableClientSideEvaluation` → `EnableLocalEvaluation`
- `EnvironmentRefreshIntervalSeconds` (int) → `EnvironmentRefreshInterval` (TimeSpan)

`version.txt` and `CHANGELOG.md` are intentionally untouched. release-please will bump 0.2.1 → 0.3.0 from the `feat!:` marker per the existing `bump-minor-pre-major` config.

### Follow-up Tasks

- None required. The version range `[8.0,10.0)` covers both 8.x and 9.x because both expose the same `FlagsmithConfiguration` shape and the same single-arg `FlagsmithClient` ctor. If 8.x support is later considered out of scope, the range can be tightened to `[9.0,10.0)` in a follow up.

### How to test

```bash
dotnet restore
dotnet build test/OpenFeature.Contrib.Providers.Flagsmith.Test/OpenFeature.Contrib.Providers.Flagsmith.Test.csproj
dotnet test --no-build test/OpenFeature.Contrib.Providers.Flagsmith.Test/OpenFeature.Contrib.Providers.Flagsmith.Test.csproj
```

Verified locally in a `mcr.microsoft.com/dotnet/sdk:10.0` container:

- Provider compiles against `Flagsmith [8.0,10.0)` for `net8.0` and `net9.0`.
- 31/31 unit tests pass against Flagsmith 8.0.0 (lowest in range) and 9.x.
- CS7069 reproduced with published 0.2.1 + Flagsmith 9.0.0 in a standalone consumer; confirmed the fix eliminates the error.
- `dotnet format --verify-no-changes` clean for changed projects.