### PR TITLE
feat: make use of flagd-selector header in RPC mode

### DIFF
--- a/src/OpenFeature.Providers.Flagd/FlagdConfig.cs
+++ b/src/OpenFeature.Providers.Flagd/FlagdConfig.cs
@@ -156,7 +156,8 @@ public class FlagdConfig
     }
 
     /// <summary>
-    ///     Source selector for the in-process provider.
+    ///     Selects which flag set the provider sees from the flagd source.
+    ///     Supported by both the in-process and RPC resolvers.
     /// </summary>
     public string SourceSelector
     {
@@ -320,7 +321,8 @@ public class FlagdConfigBuilder
     }
 
     /// <summary>
-    ///     Source selector for the in-process provider.
+    ///     Selects which flag set the provider sees from the flagd source.
+    ///     Supported by both the in-process and RPC resolvers.
     /// </summary>
     public FlagdConfigBuilder WithSourceSelector(string sourceSelector)
     {

--- a/src/OpenFeature.Providers.Flagd/Resolver/Rpc/RpcResolver.cs
+++ b/src/OpenFeature.Providers.Flagd/Resolver/Rpc/RpcResolver.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
+using Grpc.Core.Interceptors;
 using Grpc.Net.Client;
 using OpenFeature.Constant;
 using OpenFeature.Error;
@@ -559,7 +560,7 @@ internal class RpcResolver : Resolver
             {
                 HttpHandler = handler
             });
-            return new Service.ServiceClient(_channel);
+            return BuildServiceClient(_channel, config);
         }
 
 #if NET5_0_OR_GREATER
@@ -576,9 +577,20 @@ internal class RpcResolver : Resolver
         {
             HttpHandler = socketsHttpHandler,
         });
-        return new Service.ServiceClient(_channel);
+        return BuildServiceClient(_channel, config);
 #endif
         // unix socket support is not available in this dotnet version
         throw new Exception("unix sockets are not supported in this version.");
+    }
+
+    private static Service.ServiceClient BuildServiceClient(GrpcChannel channel, FlagdConfig config)
+    {
+        if (string.IsNullOrEmpty(config.SourceSelector))
+        {
+            return new Service.ServiceClient(channel);
+        }
+
+        var invoker = channel.Intercept(new SelectorInterceptor(config.SourceSelector));
+        return new Service.ServiceClient(invoker);
     }
 }

--- a/src/OpenFeature.Providers.Flagd/Resolver/Rpc/SelectorInterceptor.cs
+++ b/src/OpenFeature.Providers.Flagd/Resolver/Rpc/SelectorInterceptor.cs
@@ -1,0 +1,45 @@
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+
+namespace OpenFeature.Providers.Flagd.Resolver.Rpc;
+
+/// <summary>
+/// gRPC client interceptor that adds the <c>flagd-selector</c> metadata header
+/// to outgoing calls so the flagd server can serve the requested flag set.
+/// </summary>
+internal class SelectorInterceptor : Interceptor
+{
+    private readonly string _selector;
+
+    internal SelectorInterceptor(string selector)
+    {
+        _selector = selector;
+    }
+
+    public override AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(
+        TRequest request,
+        ClientInterceptorContext<TRequest, TResponse> context,
+        AsyncUnaryCallContinuation<TRequest, TResponse> continuation)
+    {
+        return continuation(request, WithSelector(context));
+    }
+
+    public override AsyncServerStreamingCall<TResponse> AsyncServerStreamingCall<TRequest, TResponse>(
+        TRequest request,
+        ClientInterceptorContext<TRequest, TResponse> context,
+        AsyncServerStreamingCallContinuation<TRequest, TResponse> continuation)
+    {
+        return continuation(request, WithSelector(context));
+    }
+
+    private ClientInterceptorContext<TRequest, TResponse> WithSelector<TRequest, TResponse>(
+        ClientInterceptorContext<TRequest, TResponse> context)
+        where TRequest : class
+        where TResponse : class
+    {
+        var headers = context.Options.Headers ?? new Metadata();
+        headers.Add(FlagdConfig.FlagdSelectorHeaderName, _selector);
+        var options = context.Options.WithHeaders(headers);
+        return new ClientInterceptorContext<TRequest, TResponse>(context.Method, context.Host, options);
+    }
+}

--- a/src/OpenFeature.Providers.Flagd/Resolver/Rpc/SelectorInterceptor.cs
+++ b/src/OpenFeature.Providers.Flagd/Resolver/Rpc/SelectorInterceptor.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Grpc.Core;
 using Grpc.Core.Interceptors;
 
@@ -38,12 +39,9 @@ internal class SelectorInterceptor : Interceptor
         where TResponse : class
     {
         var headers = new Metadata();
-        if (context.Options.Headers != null)
+        foreach (var entry in context.Options.Headers ?? Enumerable.Empty<Metadata.Entry>())
         {
-            foreach (var entry in context.Options.Headers)
-            {
-                headers.Add(entry);
-            }
+            headers.Add(entry);
         }
         headers.Add(FlagdConfig.FlagdSelectorHeaderName, _selector);
         var options = context.Options.WithHeaders(headers);

--- a/src/OpenFeature.Providers.Flagd/Resolver/Rpc/SelectorInterceptor.cs
+++ b/src/OpenFeature.Providers.Flagd/Resolver/Rpc/SelectorInterceptor.cs
@@ -37,7 +37,14 @@ internal class SelectorInterceptor : Interceptor
         where TRequest : class
         where TResponse : class
     {
-        var headers = context.Options.Headers ?? new Metadata();
+        var headers = new Metadata();
+        if (context.Options.Headers != null)
+        {
+            foreach (var entry in context.Options.Headers)
+            {
+                headers.Add(entry);
+            }
+        }
         headers.Add(FlagdConfig.FlagdSelectorHeaderName, _selector);
         var options = context.Options.WithHeaders(headers);
         return new ClientInterceptorContext<TRequest, TResponse>(context.Method, context.Host, options);

--- a/test/OpenFeature.Providers.Flagd.Test/Resolver/Rpc/SelectorInterceptorTests.cs
+++ b/test/OpenFeature.Providers.Flagd.Test/Resolver/Rpc/SelectorInterceptorTests.cs
@@ -1,0 +1,42 @@
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+using OpenFeature.Providers.Flagd.Resolver.Rpc;
+using Xunit;
+
+namespace OpenFeature.Providers.Flagd.Test.Resolver.Rpc;
+
+public class SelectorInterceptorTests
+{
+    private static readonly Method<string, string> _method = new Method<string, string>(
+        MethodType.Unary,
+        "test.Service",
+        "Test",
+        new Marshaller<string>(s => System.Text.Encoding.UTF8.GetBytes(s), b => System.Text.Encoding.UTF8.GetString(b)),
+        new Marshaller<string>(s => System.Text.Encoding.UTF8.GetBytes(s), b => System.Text.Encoding.UTF8.GetString(b)));
+
+    [Fact]
+    public void AsyncUnaryCall_AddsFlagdSelectorHeader()
+    {
+        var interceptor = new SelectorInterceptor("my-selector");
+        var context = new ClientInterceptorContext<string, string>(_method, host: null, options: default);
+
+        ClientInterceptorContext<string, string>? capturedContext = null;
+        var fakeCall = new AsyncUnaryCall<string>(
+            System.Threading.Tasks.Task.FromResult(string.Empty),
+            System.Threading.Tasks.Task.FromResult(new Metadata()),
+            () => Status.DefaultSuccess,
+            () => new Metadata(),
+            () => { });
+
+        interceptor.AsyncUnaryCall("req", context, (req, ctx) =>
+        {
+            capturedContext = ctx;
+            return fakeCall;
+        });
+
+        Assert.NotNull(capturedContext);
+        var headers = capturedContext.Value.Options.Headers;
+        Assert.NotNull(headers);
+        Assert.Contains(headers, e => e.Key == FlagdConfig.FlagdSelectorHeaderName && e.Value == "my-selector");
+    }
+}


### PR DESCRIPTION
- The in-process resolver already sends the `flagd-selector` gRPC metadata header, but the RPC resolver did not. This PR wires it up: the RPC resolver now sends the header on every call when `SourceSelector` is configured, so the flagd server can serve the requested flag set.
- Brings the .NET RPC resolver to parity with the Java and JS providers, which both already wire this header up (see flagd issue [#1814](https://github.com/open-feature/flagd/issues/1814)).
- Additive: behavior is unchanged when no selector is configured.

We missed the RPC mode in: https://github.com/open-feature/dotnet-sdk-contrib/issues/479
