### PR TITLE
chore: use last-release-sha instead of bootstrap-sha

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,5 @@
 {
-  "bootstrap-sha": "a8d756bc32781517cdca3fb40d1b49613d26d02f",
+  "last-release-sha": "a8d756bc32781517cdca3fb40d1b49613d26d02f",
   "separate-pull-requests": true,
   "signoff": "OpenFeature Bot <109696520+openfeaturebot@users.noreply.github.com>",
   "packages": {


### PR DESCRIPTION
`bootstrap-sha` is ignored once any release PR has ever been merged (per [release-please docs](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#bootstrapping)), so #672 was a no-op.

`last-release-sha` is the right knob: it overrides release-please's "find last merged release PR" detection and sets the lower bound for conventional-commit collection. This skips the stray bare `Release-As: 1.1.0` commit (9da19b5) that was incorrectly bumping unrelated packages (e.g. proposing OpenFeature.Providers.Flagd 1.1.0).

Per docs, `last-release-sha` is never auto-ignored; we should remove it once the next clean release PR for each affected package merges.