### PR TITLE
fix(flagd): apply in-process flag updates after initial sync

### DIFF
--- a/src/OpenFeature.Providers.Flagd/Resolver/InProcess/InProcessResolver.cs
+++ b/src/OpenFeature.Providers.Flagd/Resolver/InProcess/InProcessResolver.cs
@@ -58,7 +58,14 @@ internal class InProcessResolver : Resolver
     {
         await _jsonSchemaValidator.InitializeAsync().ConfigureAwait(false);
 
-        var initComplete = new TaskCompletionSource<bool>();
+        // RunContinuationsAsynchronously is required: this TCS is completed from inside
+        // the HandleEvents stream-reading loop (on the first received message). Without
+        // it, completing the TCS runs the Init() continuation synchronously on the loop
+        // thread, so the caller's post-initialization work (e.g. running the host) takes
+        // over that thread and the loop never returns to read subsequent SyncFlags
+        // messages. The result is that in-process flag configuration updates are never
+        // observed after the initial sync (until the process/stream restarts).
+        var initComplete = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         _ = Task.Run(() => HandleEvents(initComplete));
         await initComplete.Task.ConfigureAwait(false);
     }


### PR DESCRIPTION
## This PR

Fixes a bug where the **flagd in-process resolver stops applying flag updates after the initial sync**.

The in-process resolver opens a long-lived `SyncFlags` server-stream and processes pushed flag-configuration updates in `HandleEvents`. The `TaskCompletionSource` used to signal `Init()` completion was created without `RunContinuationsAsynchronously`, so completing it from inside the stream loop (on the first received message) ran the `Init()` continuation **synchronously on the stream-reading loop thread**. The caller's post-initialization work (e.g. an ASP.NET host's `app.Run()`) then took over that thread and the loop never returned to `MoveNext()` — so subsequent `SyncFlags` messages were never read and flag updates were never observed after the initial sync until the process restarted.

The fix creates the TCS with `TaskCreationOptions.RunContinuationsAsynchronously` so the `Init()` continuation no longer runs on the loop thread, letting the stream-reading loop keep running and apply live updates.

### Related Issues

Fixes #684

### Notes

- One-line behavioral change in `Resolver/InProcess/InProcessResolver.cs` (`Init()`).
- The same loop/TCS pattern exists back through the `OpenFeature.Contrib.Providers.Flagd` 0.5.0 line, so the bug isn't specific to 0.7.0.
- Verified independently that flagd pushes the updated configuration on every change (instrumented logs + `grpcurl` tapping flagd's `:8015` sync stream); the gap was purely client-side.

### Follow-up Tasks

- Consider a regression test asserting the in-process resolver applies a **second** `SyncFlags` message (i.e. a config update after init) while the caller thread is blocked.

### How to test

1. Run flagd with a file source and the in-process resolver pointed at flagd's sync port (`:8015`).
2. Set the provider on an app whose startup blocks the calling thread (e.g. ASP.NET `app.Run()` after `await Api.Instance.SetProviderAsync(...)`).
3. Evaluate a flag → correct value.
4. Change the flag at the source. **Before:** the in-process provider keeps returning the old value indefinitely (flagd's own eval API reflects the change). **After:** the provider returns the updated value within a sync round-trip, no restart needed.
