### PR TITLE
test: Replace Newtonsoft.Json in GOFeatureFlag test project

### DIFF
--- a/test/OpenFeature.Providers.GOFeatureFlag.Test/GoFeatureFlagProviderTest.cs
+++ b/test/OpenFeature.Providers.GOFeatureFlag.Test/GoFeatureFlagProviderTest.cs
@@ -2,8 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
 using OpenFeature.Constant;
 using OpenFeature.Model;
 using OpenFeature.Providers.GOFeatureFlag.Exceptions;
@@ -707,8 +707,10 @@ public class GOFeatureFlagProviderTest
                 TrackingEventDetails.Builder().Set("revenue", 123).Set("user_id", "123ABC").Build());
             await Task.Delay(TimeSpan.FromMilliseconds(500));
             var got = await mockHttp.LastRequest.Content.ReadAsStringAsync();
-            var gotJson = JObject.Parse(got);
-            Assert.NotNull(gotJson["events"].First);
+            var gotJson = JsonNode.Parse(got);
+            var events = gotJson?["events"]?.AsArray();
+            Assert.NotNull(events);
+            Assert.NotEmpty(events!);
         }
 
         [Fact(DisplayName = "Should send the evaluation information to the data collector")]
@@ -732,8 +734,10 @@ public class GOFeatureFlagProviderTest
                 TrackingEventDetails.Builder().Set("revenue", 123).Set("user_id", "123ABC").Build());
             await Task.Delay(TimeSpan.FromMilliseconds(500));
             var got = await mockHttp.LastRequest.Content.ReadAsStringAsync();
-            var gotJson = JObject.Parse(got);
-            Assert.Single(gotJson["events"]);
+            var gotJson = JsonNode.Parse(got);
+            var events = gotJson?["events"]?.AsArray();
+            Assert.NotNull(events);
+            Assert.Single(events!);
         }
 #endif
     }
@@ -760,8 +764,10 @@ public class GOFeatureFlagProviderTest
             await client.GetBooleanDetailsAsync("bool_flag", false, DefaultEvaluationContext);
             await Task.Delay(TimeSpan.FromMilliseconds(500));
             var got = await mockHttp.LastRequest.Content.ReadAsStringAsync();
-            var gotJson = JObject.Parse(got);
-            Assert.Single(gotJson["events"]);
+            var gotJson = JsonNode.Parse(got);
+            var events = gotJson?["events"]?.AsArray();
+            Assert.NotNull(events);
+            Assert.Single(events!);
             await OpenFeatureApi.Instance.ShutdownAsync();
         }
 
@@ -783,8 +789,10 @@ public class GOFeatureFlagProviderTest
             await client.GetBooleanDetailsAsync("bool_flag", false, DefaultEvaluationContext);
             await Task.Delay(TimeSpan.FromMilliseconds(500));
             var got = await mockHttp.LastRequest.Content.ReadAsStringAsync();
-            var gotJson = JObject.Parse(got);
-            Assert.Equal(2, gotJson["events"].Count());
+            var gotJson = JsonNode.Parse(got);
+            var events = gotJson?["events"]?.AsArray();
+            Assert.NotNull(events);
+            Assert.Equal(2, events!.Count);
             await OpenFeatureApi.Instance.ShutdownAsync();
         }
 #endif

--- a/test/OpenFeature.Providers.GOFeatureFlag.Test/OpenFeature.Providers.GOFeatureFlag.Test.csproj
+++ b/test/OpenFeature.Providers.GOFeatureFlag.Test/OpenFeature.Providers.GOFeatureFlag.Test.csproj
@@ -8,6 +8,5 @@
   <ItemGroup>
     <PackageReference Include="Wasmtime" Version="34.0.2"/>
     <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0"/>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
   </ItemGroup>
 </Project>

--- a/test/OpenFeature.Providers.GOFeatureFlag.Test/converters/SerializationTest.cs
+++ b/test/OpenFeature.Providers.GOFeatureFlag.Test/converters/SerializationTest.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json.Nodes;
 using OpenFeature.Model;
 using OpenFeature.Providers.GOFeatureFlag.Converters;
 using Xunit;
@@ -10,14 +10,19 @@ namespace OpenFeature.Providers.GOFeatureFlag.Test.Converters;
 
 public class SerializationTest
 {
+    private static JsonNode ParseJson(string json)
+    {
+        return JsonNode.Parse(json) ?? throw new InvalidOperationException("Unexpected null JSON node.");
+    }
+
     [Fact]
     public void ToStringDictionary_WithEmptyContext_ShouldReturnEmptyDictionary()
     {
         var evaluationContext = EvaluationContext.Builder().Build();
-        var want = JObject.Parse("{\"context\":{}}");
+        var want = ParseJson("{\"context\":{}}");
         var request = new Dictionary<string, object> { { "context", evaluationContext.AsDictionary() } };
-        var got = JObject.Parse(JsonSerializer.Serialize(request, JsonConverterExtensions.DefaultSerializerSettings));
-        Assert.True(JToken.DeepEquals(want, got), "unexpected json");
+        var got = ParseJson(JsonSerializer.Serialize(request, JsonConverterExtensions.DefaultSerializerSettings));
+        Assert.True(JsonNode.DeepEquals(want, got), "unexpected json");
     }
 
     [Fact]
@@ -29,10 +34,10 @@ public class SerializationTest
             .Build();
 
         var request = new Dictionary<string, object> { { "context", evaluationContext.AsDictionary() } };
-        var got = JObject.Parse(JsonSerializer.Serialize(request, JsonConverterExtensions.DefaultSerializerSettings));
-        var want = JObject.Parse(
+        var got = ParseJson(JsonSerializer.Serialize(request, JsonConverterExtensions.DefaultSerializerSettings));
+        var want = ParseJson(
             "{\"context\":{\"location\":\"somewhere\",\"targetingKey\":\"828c9b62-94c4-4ef3-bddc-e024bfa51a67\"}}");
-        Assert.True(JToken.DeepEquals(want, got), "unexpected json");
+        Assert.True(JsonNode.DeepEquals(want, got), "unexpected json");
     }
 
     [Fact]
@@ -43,10 +48,10 @@ public class SerializationTest
             .Set("age", 23)
             .Build();
         var request = new Dictionary<string, object> { { "context", evaluationContext.AsDictionary() } };
-        var got = JObject.Parse(JsonSerializer.Serialize(request, JsonConverterExtensions.DefaultSerializerSettings));
-        var want = JObject.Parse(
+        var got = ParseJson(JsonSerializer.Serialize(request, JsonConverterExtensions.DefaultSerializerSettings));
+        var want = ParseJson(
             "{\"context\":{\"age\":23,\"targetingKey\":\"828c9b62-94c4-4ef3-bddc-e024bfa51a67\"}}");
-        Assert.True(JToken.DeepEquals(want, got), "unexpected json");
+        Assert.True(JsonNode.DeepEquals(want, got), "unexpected json");
     }
 
     [Fact]
@@ -62,10 +67,10 @@ public class SerializationTest
             .Set("config", testStructure)
             .Build();
         var request = new Dictionary<string, object> { { "context", evaluationContext.AsDictionary() } };
-        var got = JObject.Parse(JsonSerializer.Serialize(request, JsonConverterExtensions.DefaultSerializerSettings));
-        var want = JObject.Parse(
+        var got = ParseJson(JsonSerializer.Serialize(request, JsonConverterExtensions.DefaultSerializerSettings));
+        var want = ParseJson(
             "{\"context\":{\"config\":{\"config1\":\"value1\", \"config2\":\"value2\"},\"targetingKey\":\"828c9b62-94c4-4ef3-bddc-e024bfa51a67\"}}");
-        Assert.True(JToken.DeepEquals(want, got), "unexpected json");
+        Assert.True(JsonNode.DeepEquals(want, got), "unexpected json");
     }
 
     [Fact]
@@ -83,10 +88,10 @@ public class SerializationTest
             .Build();
 
         var request = new Dictionary<string, object> { { "context", evaluationContext.AsDictionary() } };
-        var got = JObject.Parse(JsonSerializer.Serialize(request, JsonConverterExtensions.DefaultSerializerSettings));
-        var want = JObject.Parse(
+        var got = ParseJson(JsonSerializer.Serialize(request, JsonConverterExtensions.DefaultSerializerSettings));
+        var want = ParseJson(
             "{\"context\":{\"config\":{\"config3\":\"2025-09-01T00:00:00\",\"config2\":\"value2\",\"config1\":1},\"targetingKey\":\"828c9b62-94c4-4ef3-bddc-e024bfa51a67\"}}");
-        Assert.True(JToken.DeepEquals(want, got), "unexpected json");
+        Assert.True(JsonNode.DeepEquals(want, got), "unexpected json");
     }
 
     [Fact]
@@ -108,10 +113,10 @@ public class SerializationTest
             .Build();
 
         var request = new Dictionary<string, object> { { "context", evaluationContext.AsDictionary() } };
-        var got = JObject.Parse(JsonSerializer.Serialize(request, JsonConverterExtensions.DefaultSerializerSettings));
-        var want = JObject.Parse(
+        var got = ParseJson(JsonSerializer.Serialize(request, JsonConverterExtensions.DefaultSerializerSettings));
+        var want = ParseJson(
             "{\"context\":{\"config\":{\"config2\":[[\"element1-1\",\"element1-2\"],\"element2\",\"element3\"],\"config3\":\"2025-09-01T00:00:00\"},\"targetingKey\":\"828c9b62-94c4-4ef3-bddc-e024bfa51a67\"}}");
-        Assert.True(JToken.DeepEquals(want, got), "unexpected json");
+        Assert.True(JsonNode.DeepEquals(want, got), "unexpected json");
     }
 
     [Fact]
@@ -131,9 +136,9 @@ public class SerializationTest
             .Set("config", testStructure)
             .Build();
         var request = new Dictionary<string, object> { { "context", evaluationContext.AsDictionary() } };
-        var got = JObject.Parse(JsonSerializer.Serialize(request, JsonConverterExtensions.DefaultSerializerSettings));
-        var want = JObject.Parse(
+        var got = ParseJson(JsonSerializer.Serialize(request, JsonConverterExtensions.DefaultSerializerSettings));
+        var want = ParseJson(
             "{\"context\":{\"config\":{\"config-value-struct\":{\"nested1\":1},\"config-value-value\":\"2025-09-01T00:00:00\"},\"targetingKey\":\"828c9b62-94c4-4ef3-bddc-e024bfa51a67\"}}");
-        Assert.True(JToken.DeepEquals(want, got), "unexpected json");
+        Assert.True(JsonNode.DeepEquals(want, got), "unexpected json");
     }
 }

--- a/test/OpenFeature.Providers.GOFeatureFlag.Test/utils/AssertUtil.cs
+++ b/test/OpenFeature.Providers.GOFeatureFlag.Test/utils/AssertUtil.cs
@@ -1,5 +1,5 @@
 using System;
-using Newtonsoft.Json.Linq;
+using System.Text.Json.Nodes;
 using Xunit.Sdk;
 
 namespace OpenFeature.Providers.GOFeatureFlag.Test.Utils;
@@ -16,10 +16,12 @@ public class AssertUtil
             throw new ArgumentException("JSON strings cannot be null or empty.");
         }
 
-        var token1 = JObject.Parse(expectedJson);
-        var token2 = JObject.Parse(actualJson);
+        var token1 = JsonNode.Parse(expectedJson) as JsonObject
+                     ?? throw new ArgumentException("Expected JSON must be an object.");
+        var token2 = JsonNode.Parse(actualJson) as JsonObject
+                     ?? throw new ArgumentException("Actual JSON must be an object.");
 
-        if (!JToken.DeepEquals(token1, token2))
+        if (!JsonNode.DeepEquals(token1, token2))
         {
             throw new EqualException(expectedJson, actualJson);
         }


### PR DESCRIPTION
## Why
The GOFeatureFlag test project depended on `Newtonsoft.Json` only for JSON parsing/assertions. Replacing it with `System.Text.Json` removes an extra dependency and keeps tests aligned with the built-in JSON stack already used in this codebase.

## What changed
- Removed `Newtonsoft.Json` package reference from `test/OpenFeature.Providers.GOFeatureFlag.Test/OpenFeature.Providers.GOFeatureFlag.Test.csproj`.
- Migrated JSON comparison/parsing in tests from `JObject/JToken` to `System.Text.Json.Nodes.JsonNode`.
- Updated tracking-related assertions in `GoFeatureFlagProviderTest` to use explicit array checks (`AsArray`, `NotNull`, `NotEmpty`/`Single`/count).
- Preserved previous object-root semantics in `AssertUtil.JsonEqual` by requiring parsed nodes to be `JsonObject`.

## Validation
- `dotnet test test/OpenFeature.Providers.GOFeatureFlag.Test/OpenFeature.Providers.GOFeatureFlag.Test.csproj --nologo`
  - net8.0: 75 passed, 2 skipped
  - net9.0: 75 passed, 2 skipped