### PR TITLE
fix: prevent flaky RpcResolver tests and event stream hot-spin

### DIFF
--- a/src/OpenFeature.Providers.Flagd/Resolver/Rpc/RpcResolver.cs
+++ b/src/OpenFeature.Providers.Flagd/Resolver/Rpc/RpcResolver.cs
@@ -271,7 +271,7 @@ internal class RpcResolver : Resolver
                 // tight loop.
                 if (!token.IsCancellationRequested)
                 {
-                    await this.HandleErrorEvent().ConfigureAwait(false);
+                    await this.HandleErrorEvent(token).ConfigureAwait(false);
                 }
             }
             catch (OperationCanceledException)
@@ -284,7 +284,7 @@ internal class RpcResolver : Resolver
             }
             catch (RpcException)
             {
-                await this.HandleErrorEvent().ConfigureAwait(false);
+                await this.HandleErrorEvent(token).ConfigureAwait(false);
             }
         }
     }
@@ -327,8 +327,13 @@ internal class RpcResolver : Resolver
         }
     }
 
-    private async Task HandleErrorEvent()
+    private async Task HandleErrorEvent(CancellationToken token)
     {
+        if (token.IsCancellationRequested)
+        {
+            return;
+        }
+
         this._eventStreamRetries++;
 
         if (this._eventStreamRetries > this._config.MaxEventStreamRetries)
@@ -341,7 +346,14 @@ internal class RpcResolver : Resolver
 
         // Handle the dropped connection by reconnecting and retrying the stream
         this._eventStreamRetryBackoff = this._eventStreamRetryBackoff * 2;
-        await Task.Delay(this._eventStreamRetryBackoff * 1000).ConfigureAwait(false);
+        try
+        {
+            await Task.Delay(this._eventStreamRetryBackoff * 1000, token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            // shutting down; stop waiting for the backoff to elapse
+        }
     }
 
     /// <summary>

--- a/src/OpenFeature.Providers.Flagd/Resolver/Rpc/RpcResolver.cs
+++ b/src/OpenFeature.Providers.Flagd/Resolver/Rpc/RpcResolver.cs
@@ -230,7 +230,7 @@ internal class RpcResolver : Resolver
             try
             {
                 // Read the response stream asynchronously
-                while (!token.IsCancellationRequested && call != null && await call.ResponseStream.MoveNext().ConfigureAwait(false))
+                while (!token.IsCancellationRequested && call != null && await call.ResponseStream.MoveNext(token).ConfigureAwait(false))
                 {
                     var response = call.ResponseStream.Current;
 
@@ -264,6 +264,19 @@ internal class RpcResolver : Resolver
                             break;
                     }
                 }
+
+                // The stream ended gracefully without an exception (the server closed it).
+                // Unless we're shutting down, treat this like a dropped connection and go
+                // through the retry/backoff path instead of immediately reconnecting in a
+                // tight loop.
+                if (!token.IsCancellationRequested)
+                {
+                    await this.HandleErrorEvent().ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // do nothing, we've been shutdown
             }
             catch (RpcException ex) when (ex.StatusCode == StatusCode.Cancelled)
             {

--- a/test/OpenFeature.Providers.Flagd.Test/Resolver/Rpc/RpcResolverTests.cs
+++ b/test/OpenFeature.Providers.Flagd.Test/Resolver/Rpc/RpcResolverTests.cs
@@ -60,31 +60,36 @@ public class RpcResolverTests
             }
         };
 
-        var autoResetEvent = new AutoResetEvent(false);
         var mockGrpcClient = SetupGrpcStream(responses);
 
-        var config = FlagdConfig.Builder().Build();
+        var config = FlagdConfig.Builder().WithMaxEventStreamRetries(1).Build();
 
         FlagdProviderEvent flagdProviderEvent = null;
         var resolver = new RpcResolver(mockGrpcClient, config, null);
-        resolver.ProviderEvent += (sender, args) => { flagdProviderEvent = args; autoResetEvent.Set(); };
+        resolver.ProviderEvent += (sender, args) => { flagdProviderEvent = args; };
 
-        // Act
-        await resolver.Init();
+        try
+        {
+            // Act
+            await resolver.Init();
 
-        // Assert
-        Assert.True(autoResetEvent.WaitOne(TestTimeoutMilliseconds));
+            // Assert
+            await Utils.AssertUntilAsync(_ => { Assert.NotNull(flagdProviderEvent); return Task.CompletedTask; }, TestTimeoutMilliseconds);
 
-        Assert.NotNull(flagdProviderEvent);
-        Assert.Equal(ProviderEventTypes.ProviderReady, flagdProviderEvent.EventType);
-        Assert.Contains("key1", flagdProviderEvent.FlagsChanged);
-        Assert.Contains("key1", flagdProviderEvent.FlagsChanged);
-        Assert.Contains("key2", flagdProviderEvent.FlagsChanged);
-        Assert.Contains("key3", flagdProviderEvent.FlagsChanged);
-        Assert.Contains("key4", flagdProviderEvent.FlagsChanged);
-        Assert.Contains("key5", flagdProviderEvent.FlagsChanged);
-        Assert.Contains("key6", flagdProviderEvent.FlagsChanged);
-        Assert.Equal(Structure.Empty, flagdProviderEvent.SyncMetadata);
+            Assert.Equal(ProviderEventTypes.ProviderReady, flagdProviderEvent.EventType);
+            Assert.Contains("key1", flagdProviderEvent.FlagsChanged);
+            Assert.Contains("key1", flagdProviderEvent.FlagsChanged);
+            Assert.Contains("key2", flagdProviderEvent.FlagsChanged);
+            Assert.Contains("key3", flagdProviderEvent.FlagsChanged);
+            Assert.Contains("key4", flagdProviderEvent.FlagsChanged);
+            Assert.Contains("key5", flagdProviderEvent.FlagsChanged);
+            Assert.Contains("key6", flagdProviderEvent.FlagsChanged);
+            Assert.Equal(Structure.Empty, flagdProviderEvent.SyncMetadata);
+        }
+        finally
+        {
+            await resolver.Shutdown();
+        }
     }
 
     [Fact]
@@ -100,25 +105,30 @@ public class RpcResolverTests
             }
         };
 
-        var autoResetEvent = new AutoResetEvent(false);
         var mockGrpcClient = SetupGrpcStream(responses);
 
-        var config = FlagdConfig.Builder().Build();
+        var config = FlagdConfig.Builder().WithMaxEventStreamRetries(1).Build();
 
         FlagdProviderEvent flagdProviderEvent = null;
         var resolver = new RpcResolver(mockGrpcClient, config, null);
-        resolver.ProviderEvent += (sender, args) => { flagdProviderEvent = args; autoResetEvent.Set(); };
+        resolver.ProviderEvent += (sender, args) => { flagdProviderEvent = args; };
 
-        // Act
-        await resolver.Init();
+        try
+        {
+            // Act
+            await resolver.Init();
 
-        // Assert
-        Assert.True(autoResetEvent.WaitOne(TestTimeoutMilliseconds));
+            // Assert
+            await Utils.AssertUntilAsync(_ => { Assert.NotNull(flagdProviderEvent); return Task.CompletedTask; }, TestTimeoutMilliseconds);
 
-        Assert.NotNull(flagdProviderEvent);
-        Assert.Equal(ProviderEventTypes.ProviderReady, flagdProviderEvent.EventType);
-        Assert.Empty(flagdProviderEvent.FlagsChanged);
-        Assert.Equal(Structure.Empty, flagdProviderEvent.SyncMetadata);
+            Assert.Equal(ProviderEventTypes.ProviderReady, flagdProviderEvent.EventType);
+            Assert.Empty(flagdProviderEvent.FlagsChanged);
+            Assert.Equal(Structure.Empty, flagdProviderEvent.SyncMetadata);
+        }
+        finally
+        {
+            await resolver.Shutdown();
+        }
     }
 
     [Fact]
@@ -141,25 +151,30 @@ public class RpcResolverTests
             }
         };
 
-        var autoResetEvent = new AutoResetEvent(false);
         var mockGrpcClient = SetupGrpcStream(responses);
 
-        var config = FlagdConfig.Builder().Build();
+        var config = FlagdConfig.Builder().WithMaxEventStreamRetries(1).Build();
 
         FlagdProviderEvent flagdProviderEvent = null;
         var resolver = new RpcResolver(mockGrpcClient, config, null);
-        resolver.ProviderEvent += (sender, args) => { flagdProviderEvent = args; autoResetEvent.Set(); };
+        resolver.ProviderEvent += (sender, args) => { flagdProviderEvent = args; };
 
-        // Act
-        await resolver.Init();
+        try
+        {
+            // Act
+            await resolver.Init();
 
-        // Assert
-        Assert.True(autoResetEvent.WaitOne(TestTimeoutMilliseconds));
+            // Assert
+            await Utils.AssertUntilAsync(_ => { Assert.NotNull(flagdProviderEvent); return Task.CompletedTask; }, TestTimeoutMilliseconds);
 
-        Assert.NotNull(flagdProviderEvent);
-        Assert.Equal(ProviderEventTypes.ProviderConfigurationChanged, flagdProviderEvent.EventType);
-        Assert.Contains("key1", flagdProviderEvent.FlagsChanged);
-        Assert.Equal(Structure.Empty, flagdProviderEvent.SyncMetadata);
+            Assert.Equal(ProviderEventTypes.ProviderConfigurationChanged, flagdProviderEvent.EventType);
+            Assert.Contains("key1", flagdProviderEvent.FlagsChanged);
+            Assert.Equal(Structure.Empty, flagdProviderEvent.SyncMetadata);
+        }
+        finally
+        {
+            await resolver.Shutdown();
+        }
     }
 
     [Fact]
@@ -182,27 +197,31 @@ public class RpcResolverTests
             }
         };
 
-        var autoResetEvent = new AutoResetEvent(false);
         var mockGrpcClient = SetupGrpcStream(responses);
 
         var config = FlagdConfig.Builder()
             .WithCache(true)
+            .WithMaxEventStreamRetries(1)
             .Build();
 
         var mockCache = Substitute.For<ICache<string, object>>();
         mockCache.TryGet(Arg.Is<string>(s => s == "key1")).Returns(null);
         mockCache.Add(Arg.Is<string>(s => s == "key1"), Arg.Any<object>());
-        mockCache.When(x => x.Purge()).Do(_ => { autoResetEvent.Set(); });
 
         var resolver = new RpcResolver(mockGrpcClient, config, mockCache);
 
-        // Act
-        await resolver.Init();
+        try
+        {
+            // Act
+            await resolver.Init();
 
-        // Assert
-        Assert.True(autoResetEvent.WaitOne(TestTimeoutMilliseconds));
-
-        mockCache.Received().Purge();
+            // Assert
+            await Utils.AssertUntilAsync(_ => { mockCache.Received().Purge(); return Task.CompletedTask; }, TestTimeoutMilliseconds);
+        }
+        finally
+        {
+            await resolver.Shutdown();
+        }
     }
 
     [Fact]
@@ -225,27 +244,31 @@ public class RpcResolverTests
             }
         };
 
-        var autoResetEvent = new AutoResetEvent(false);
         var mockGrpcClient = SetupGrpcStream(responses);
 
         var config = FlagdConfig.Builder()
             .WithCache(true)
+            .WithMaxEventStreamRetries(1)
             .Build();
 
         var mockCache = Substitute.For<ICache<string, object>>();
         mockCache.TryGet(Arg.Is<string>(s => s == "key1")).Returns(null);
         mockCache.Add(Arg.Is<string>(s => s == "key1"), Arg.Any<object>());
-        mockCache.When(x => x.Delete("key1")).Do(_ => { autoResetEvent.Set(); });
 
         var resolver = new RpcResolver(mockGrpcClient, config, mockCache);
 
-        // Act
-        await resolver.Init();
+        try
+        {
+            // Act
+            await resolver.Init();
 
-        // Assert
-        Assert.True(autoResetEvent.WaitOne(TestTimeoutMilliseconds));
-
-        mockCache.Received().Delete("key1");
+            // Assert
+            await Utils.AssertUntilAsync(_ => { mockCache.Received().Delete("key1"); return Task.CompletedTask; }, TestTimeoutMilliseconds);
+        }
+        finally
+        {
+            await resolver.Shutdown();
+        }
     }
 
     [Theory]
@@ -407,7 +430,18 @@ public class RpcResolverTests
         var asyncStreamReader = Substitute.For<IAsyncStreamReader<EventStreamResponse>>();
 
         var enumerator = responses.GetEnumerator();
-        asyncStreamReader.MoveNext(Arg.Any<CancellationToken>()).Returns(_ => enumerator.MoveNext());
+        asyncStreamReader.MoveNext(Arg.Any<CancellationToken>()).Returns(callInfo =>
+        {
+            if (enumerator.MoveNext())
+            {
+                return Task.FromResult(true);
+            }
+
+            // Emulate a real, long-lived gRPC stream that stays open until it is closed,
+            // instead of signalling end-of-stream immediately (which makes the resolver
+            // reconnect in a tight, CPU-bound loop and leaks a spinning background task).
+            return WaitForCancellationAsync(callInfo.Arg<CancellationToken>());
+        });
         asyncStreamReader.Current.Returns(_ => enumerator.Current);
 
         var grpcEventStreamResp = new AsyncServerStreamingCall<EventStreamResponse>(asyncStreamReader, null, null, null, null, null);
@@ -415,5 +449,19 @@ public class RpcResolverTests
             .Returns(grpcEventStreamResp);
 
         return mockGrpcClient;
+    }
+
+    private static async Task<bool> WaitForCancellationAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // The stream was closed (resolver shut down).
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
## Why

`RpcResolver` event-stream tests fail intermittently on `windows-latest` (for example [this run](https://github.com/open-feature/dotnet-sdk-contrib/actions/runs/27900850597)) with:

```
Assert.True() Failure - Expected: True, Actual: False
at RpcResolverTests.HandleEvents_WithNoFlags_CallsFlagdProviderEventHandler
```

## Root cause

The mocked gRPC stream signalled end-of-stream **immediately** once its responses were consumed. `RpcResolver.HandleEvents` only increments its retry counter inside `catch (RpcException)`, so when `MoveNext` returns `false` (rather than throwing) the retry bound is never reached and the inner `await MoveNext()` completes synchronously. The loop then reconnects in an unbounded, never-awaiting **hot CPU spin**.

Because the tests never called `Shutdown()` (unlike `InProcessResolverTests`), each test **leaked a busy-spinning background task**. xUnit runs test classes in parallel, so the accumulated spinners saturated the 2-core Windows runner and the 10s waits timed out. The same loop is a latent production bug: a gracefully closed stream would hot-spin in the field.

## Approach

**Production (`RpcResolver.HandleEvents`)**
- Pass the cancellation token to `MoveNext(token)` so the read is cancellable and shutdown is responsive.
- Catch `OperationCanceledException` for graceful shutdown.
- On a graceful end-of-stream (loop exits while not cancelled), route through the existing `HandleErrorEvent()` retry/backoff path (bounded by `MaxEventStreamRetries`) instead of immediately reconnecting in a tight loop.

**Tests (`RpcResolverTests`)**
- `SetupGrpcStream` now emulates a real long-lived stream: after yielding the configured responses it parks on the supplied cancellation token instead of returning `false` instantly, eliminating the in-test hot-spin.
- Each `HandleEvents_*` test shuts the resolver down in a `finally` and sets `WithMaxEventStreamRetries(1)`, mirroring `InProcessResolverTests`, so no background task leaks between tests.
- Blocking `AutoResetEvent.WaitOne(10_000)` waits are replaced with the existing async `Utils.AssertUntilAsync` helper, so tests no longer block a thread-pool thread or depend on real-time scheduling under CPU pressure. All existing assertions are preserved.

## Notes for reviewers

- The behavior change worth a careful look: a graceful end-of-stream now emits a `ProviderError` and backs off (bounded) rather than silently hot-reconnecting. In practice flagd closes the stream via an `RpcException`, so this path is defensive, but it removes the unbounded spin at the source.

## Verification

- Full Flagd suite green on net8.0 (166) and net9.0 (166); `src` builds on all TFMs including net462.
- `RpcResolverTests` stable across 5 consecutive runs (~390ms each); the net8.0 suite dropped from ~46s to under 1s now that the spin is gone.
- `dotnet format --verify-no-changes` clean on the changed files.