### PR TITLE
chore(configcat)!: Update ConfigCat provider to use the latest ConfigCat SDK

### DIFF
--- a/src/OpenFeature.Contrib.Providers.ConfigCat/ConfigCatProvider.cs
+++ b/src/OpenFeature.Contrib.Providers.ConfigCat/ConfigCatProvider.cs
@@ -24,7 +24,7 @@ public sealed class ConfigCatProvider : FeatureProvider
     /// <param name="configBuilder">The action used to configure the client.</param>
     /// <exception cref="ArgumentNullException"><paramref name="sdkKey"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException"><paramref name="sdkKey"/> is an empty string or in an invalid format.</exception>
-    public ConfigCatProvider(string sdkKey, Action<ConfigCatClientOptions> configBuilder = null)
+    public ConfigCatProvider(string sdkKey, Action<ConfigCatClientOptions>? configBuilder = null)
     {
         Client = ConfigCatClient.Get(sdkKey, configBuilder);
     }
@@ -49,35 +49,35 @@ public sealed class ConfigCatProvider : FeatureProvider
     }
 
     /// <inheritdoc/>
-    public override Task<ResolutionDetails<bool>> ResolveBooleanValueAsync(string flagKey, bool defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
+    public override Task<ResolutionDetails<bool>> ResolveBooleanValueAsync(string flagKey, bool defaultValue, EvaluationContext? context = null, CancellationToken cancellationToken = default)
     {
         return ResolveFlag(flagKey, context, defaultValue, cancellationToken);
     }
 
     /// <inheritdoc/>
-    public override Task<ResolutionDetails<string>> ResolveStringValueAsync(string flagKey, string defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
+    public override Task<ResolutionDetails<string>> ResolveStringValueAsync(string flagKey, string defaultValue, EvaluationContext? context = null, CancellationToken cancellationToken = default)
     {
         return ResolveFlag(flagKey, context, defaultValue, cancellationToken);
     }
 
     /// <inheritdoc/>
-    public override Task<ResolutionDetails<int>> ResolveIntegerValueAsync(string flagKey, int defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
+    public override Task<ResolutionDetails<int>> ResolveIntegerValueAsync(string flagKey, int defaultValue, EvaluationContext? context = null, CancellationToken cancellationToken = default)
     {
         return ResolveFlag(flagKey, context, defaultValue, cancellationToken);
     }
 
     /// <inheritdoc/>
-    public override Task<ResolutionDetails<double>> ResolveDoubleValueAsync(string flagKey, double defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
+    public override Task<ResolutionDetails<double>> ResolveDoubleValueAsync(string flagKey, double defaultValue, EvaluationContext? context = null, CancellationToken cancellationToken = default)
     {
         return ResolveFlag(flagKey, context, defaultValue, cancellationToken);
     }
 
     /// <inheritdoc/>
-    public override async Task<ResolutionDetails<Value>> ResolveStructureValueAsync(string flagKey, Value defaultValue, EvaluationContext context = null, CancellationToken cancellationToken = default)
+    public override async Task<ResolutionDetails<Value>> ResolveStructureValueAsync(string flagKey, Value defaultValue, EvaluationContext? context = null, CancellationToken cancellationToken = default)
     {
         var user = context?.BuildUser();
-        var result = await Client.GetValueDetailsAsync(flagKey, defaultValue?.AsObject, user, cancellationToken).ConfigureAwait(false);
-        var returnValue = result.IsDefaultValue ? defaultValue : new Value(result.Value);
+        var result = await Client.GetValueDetailsAsync(flagKey, defaultValue.AsObject, user, cancellationToken).ConfigureAwait(false);
+        var returnValue = result.IsDefaultValue ? defaultValue : new Value(result.Value!);
         var details = new ResolutionDetails<Value>(flagKey, returnValue, TranslateErrorCode(result.ErrorCode), errorMessage: result.ErrorMessage, variant: result.VariationId);
         if (details.ErrorType == ErrorType.None)
         {
@@ -87,7 +87,7 @@ public sealed class ConfigCatProvider : FeatureProvider
         throw new FeatureProviderException(details.ErrorType, details.ErrorMessage);
     }
 
-    private async Task<ResolutionDetails<T>> ResolveFlag<T>(string flagKey, EvaluationContext context, T defaultValue, CancellationToken cancellationToken)
+    private async Task<ResolutionDetails<T>> ResolveFlag<T>(string flagKey, EvaluationContext? context, T defaultValue, CancellationToken cancellationToken)
     {
         var user = context?.BuildUser();
         var result = await Client.GetValueDetailsAsync(flagKey, defaultValue, user, cancellationToken).ConfigureAwait(false);

--- a/src/OpenFeature.Contrib.Providers.ConfigCat/OpenFeature.Contrib.Providers.ConfigCat.csproj
+++ b/src/OpenFeature.Contrib.Providers.ConfigCat/OpenFeature.Contrib.Providers.ConfigCat.csproj
@@ -9,6 +9,7 @@
     <Description>ConfigCat provider for .NET</Description>
     <Authors>Luiz Bon</Authors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <!-- make the internal methods visble to our test project -->

--- a/src/OpenFeature.Contrib.Providers.ConfigCat/OpenFeature.Contrib.Providers.ConfigCat.csproj
+++ b/src/OpenFeature.Contrib.Providers.ConfigCat/OpenFeature.Contrib.Providers.ConfigCat.csproj
@@ -17,7 +17,7 @@
     </AssemblyAttribute>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ConfigCat.Client" Version="9.3.2" />
+    <PackageReference Include="ConfigCat.Client" Version="10.0.0" />
     <PackageReference Include="OpenFeature" Version="[2.0,3.0)" />
   </ItemGroup>
 </Project>

--- a/src/OpenFeature.Contrib.Providers.ConfigCat/README.md
+++ b/src/OpenFeature.Contrib.Providers.ConfigCat/README.md
@@ -1,6 +1,6 @@
 # ConfigCat Feature Flag .NET Provider
 
-The ConfigCat Flag provider allows you to connect to your ConfigCat instance.
+The ConfigCat provider allows you to use [ConfigCat](https://configcat.com) with the OpenFeature .NET SDK.
 
 # .NET SDK usage
 
@@ -97,22 +97,24 @@ await OpenFeature.Api.Instance.ShutdownAsync();
 ## EvaluationContext and ConfigCat User Object relationship
 
 An <a href="https://openfeature.dev/docs/reference/concepts/evaluation-context" target="_blank">evaluation context</a> in the OpenFeature specification is a container for arbitrary contextual data that can be used as a basis for feature flag evaluation.
-The ConfigCat provider translates these evaluation contexts to ConfigCat [User Objects](https://configcat.com/docs/targeting/user-object/).
 
-The ConfigCat User Object has a few pre-defined attributes that can be used to evaluate a flag. These are:
+The ConfigCat provider translates these evaluation contexts to ConfigCat [User Objects](https://configcat.com/docs/targeting/user-object/), which have three predefined attributes and allow for additional custom attributes.
 
-| Attribute    | Description                                                                                                    |
-|--------------|----------------------------------------------------------------------------------------------------------------|
-| `Identifier` | *REQUIRED*. Unique identifier of a user in your application. Can be any `string` value, even an email address. |
-| `Email`      | The email address of the user.                                                                                 |
-| `Country`    | The country of the user.                                                                                       |
+The following table shows how the attributes are mapped:
 
-Since `EvaluationContext` is a simple dictionary, the provider will try to match the keys to ConfigCat user attributes following the table below in a case-insensitive manner.
+| EvaluationContext Key                | ConfigCat User Property |
+| ------------------------------------ | ----------------------- |
+| `targetingKey`                       | Identifier              |
+| `id` (or `Id`, `ID`, etc.)           | Identifier              |
+| `identifier` (or `Identifier`, etc.) | Identifier              |
+| `email` (or `Email`, etc.)           | Email                   |
+| `country` (or `Country`, etc.)       | Country                 |
+| Any Other                            | Custom                  |
 
-| EvaluationContext Key | ConfigCat User Attribute |
-|-----------------------|--------------------------|
-| `id`                  | `Identifier`             |
-| `identifier`          | `Identifier`             |
-| `email`               | `Email`                  |
-| `country`             | `Country`                |
-| Any other             | `Custom`                 |
+Remarks:
+- If `targetingKey` is specified, it will be mapped to the `Identifier` property, regardless of other identifier attributes.
+- If `targetingKey` is not specified, `id` or `identifier` will be mapped to the `Identifier` property, whichever occurs first. These keys are matched case-insensitively, so for example, `ID` or `Identifier` would also work.
+- If no identifier attribute is specified, the `Identifier` property will be set to the fallback value `<n/a>`.
+- The keys `email` and `country` are also matched case-insensitively. If the same key appears in multiple cases - e.g. `email` and `EMAIL` - the first occurrence will be mapped to the corresponding property.
+- All of the above will also be included in the `Custom` dictionary, except for the exact keys `Identifier`, `Email`, and `Country`. This allows them to be referenced using their original names in feature flag rules.
+- Other keys are mapped as custom user attributes with their values unchanged. (Although the ConfigCat SDK handles value conversion internally, it's recommended to use the type expected by the referencing feature flag rules. Read more [here](https://configcat.com/docs/sdk-reference/dotnet/#user-object-attribute-types).)

--- a/src/OpenFeature.Contrib.Providers.ConfigCat/README.md
+++ b/src/OpenFeature.Contrib.Providers.ConfigCat/README.md
@@ -102,19 +102,16 @@ The ConfigCat provider translates these evaluation contexts to ConfigCat [User O
 
 The following table shows how the attributes are mapped:
 
-| EvaluationContext Key                | ConfigCat User Property |
+| EvaluationContext key                | User Object property    |
 | ------------------------------------ | ----------------------- |
-| `targetingKey`                       | Identifier              |
-| `id` (or `Id`, `ID`, etc.)           | Identifier              |
-| `identifier` (or `Identifier`, etc.) | Identifier              |
-| `email` (or `Email`, etc.)           | Email                   |
-| `country` (or `Country`, etc.)       | Country                 |
+| `targetingKey` (`Id` / `Identifier`) | Identifier              |
+| `Email`                              | Email                   |
+| `Country`                            | Country                 |
 | Any Other                            | Custom                  |
 
 Remarks:
-- If `targetingKey` is specified, it will be mapped to the `Identifier` property, regardless of other identifier attributes.
-- If `targetingKey` is not specified, `id` or `identifier` will be mapped to the `Identifier` property, whichever occurs first. These keys are matched case-insensitively, so for example, `ID` or `Identifier` would also work.
-- If no identifier attribute is specified, the `Identifier` property will be set to the fallback value `<n/a>`.
-- The keys `email` and `country` are also matched case-insensitively. If the same key appears in multiple cases - e.g. `email` and `EMAIL` - the first occurrence will be mapped to the corresponding property.
-- All of the above will also be included in the `Custom` dictionary, except for the exact keys `Identifier`, `Email`, and `Country`. This allows them to be referenced using their original names in feature flag rules.
+- If `targetingKey` is present in the evaluation context, it will be mapped to the `Identifier` property. Otherwise, `Id` or `Identifier` will be mapped, whichever occurs first.
+  (If none of these keys are present, the `Identifier` property will be set to the fallback value `"<n/a>"`.)
+- The keys `Id`, `Identifier`, `Email` and `Country` are matched case-insensitively. If the same key appears in multiple cases - e.g. `email` and `Email` - the first occurrence will be mapped to the corresponding property.
+- All of the above will also be included in the `Custom` dictionary (except for the exact keys `Identifier`, `Email` and `Country`). This allows them to be referenced using their original names in feature flag rules.
 - Other keys are mapped as custom user attributes with their values unchanged. (Although the ConfigCat SDK handles value conversion internally, it's recommended to use the type expected by the referencing feature flag rules. Read more [here](https://configcat.com/docs/sdk-reference/dotnet/#user-object-attribute-types).)

--- a/src/OpenFeature.Contrib.Providers.ConfigCat/UserBuilder.cs
+++ b/src/OpenFeature.Contrib.Providers.ConfigCat/UserBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using ConfigCat.Client;
 using OpenFeature.Model;
@@ -16,31 +17,41 @@ internal static class UserBuilder
             return null;
         }
 
-        var user = new User(context.GetUserId());
+        string? identifier = context.TargetingKey, email = null, country = null;
+        Dictionary<string, object>? customAttributes = null;
 
-        foreach (var value in context)
+        foreach (var entry in context)
         {
-            if (StringComparer.OrdinalIgnoreCase.Equals("EMAIL", value.Key))
+            // NOTE: Attribute key matching shouldn't really be case-insensitive as it may lead to confusing behavior
+            // in some edge cases. However, fixing this would be a significant breaking change, so we keep it this way.
+
+            if (identifier is null && PossibleUserIds.Contains(entry.Key, StringComparer.OrdinalIgnoreCase))
             {
-                user.Email = value.Value.AsString;
+                identifier = entry.Value.AsString;
             }
-            else if (StringComparer.OrdinalIgnoreCase.Equals("COUNTRY", value.Key))
+            else if (email is null && StringComparer.OrdinalIgnoreCase.Equals("EMAIL", entry.Key))
             {
-                user.Country = value.Value.AsString;
+                email = entry.Value.AsString;
             }
-            else
+            else if (country is null && StringComparer.OrdinalIgnoreCase.Equals("COUNTRY", entry.Key))
             {
-                user.Custom.Add(value.Key, value.Value.AsString!);
+                country = entry.Value.AsString;
+            }
+
+            if (!entry.Value.IsNull && entry.Key is not (nameof(User.Identifier) or nameof(User.Email) or nameof(User.Country)))
+            {
+                // NOTE: No need to check for unsupported attribute values as the ConfigCat SDK handles those internally.
+                (customAttributes ??= new())[entry.Key] = entry.Value.AsObject!;
             }
         }
 
+        var user = new User(identifier ?? "<n/a>")
+        {
+            Email = email,
+            Country = country,
+            Custom = customAttributes!
+        };
+
         return user;
-    }
-
-    private static string GetUserId(this EvaluationContext context)
-    {
-        var pair = context.AsDictionary().FirstOrDefault(x => PossibleUserIds.Contains(x.Key, StringComparer.OrdinalIgnoreCase));
-
-        return pair.Key != null ? pair.Value.AsString! : "<n/a>";
     }
 }

--- a/src/OpenFeature.Contrib.Providers.ConfigCat/UserBuilder.cs
+++ b/src/OpenFeature.Contrib.Providers.ConfigCat/UserBuilder.cs
@@ -9,9 +9,9 @@ internal static class UserBuilder
 {
     private static readonly string[] PossibleUserIds = { "ID", "IDENTIFIER" };
 
-    internal static User BuildUser(this EvaluationContext context)
+    internal static User? BuildUser(this EvaluationContext? context)
     {
-        if (context == null)
+        if (context is null)
         {
             return null;
         }
@@ -30,7 +30,7 @@ internal static class UserBuilder
             }
             else
             {
-                user.Custom.Add(value.Key, value.Value.AsString);
+                user.Custom.Add(value.Key, value.Value.AsString!);
             }
         }
 
@@ -41,6 +41,6 @@ internal static class UserBuilder
     {
         var pair = context.AsDictionary().FirstOrDefault(x => PossibleUserIds.Contains(x.Key, StringComparer.OrdinalIgnoreCase));
 
-        return pair.Key != null ? pair.Value.AsString : "<n/a>";
+        return pair.Key != null ? pair.Value.AsString! : "<n/a>";
     }
 }

--- a/test/OpenFeature.Contrib.Providers.ConfigCat.Test/UserBuilderTests.cs
+++ b/test/OpenFeature.Contrib.Providers.ConfigCat.Test/UserBuilderTests.cs
@@ -5,57 +5,138 @@ namespace OpenFeature.Contrib.ConfigCat.Test;
 
 public class UserBuilderTests
 {
-    [Theory]
-    [InlineData("id", "test")]
-    [InlineData("identifier", "test")]
-    public void UserBuilder_Should_Map_Identifiers(string key, string value)
+    [Fact]
+    public void UserBuilder_Should_Use_Fallback_Value_When_ID_Is_Not_Specified()
     {
         // Arrange
-        var context = EvaluationContext.Builder().Set(key, value).Build();
+        var context = EvaluationContext.Builder()
+            .Set("ID2", "test1")
+            .Set("IdentifierKey", "test2")
+            .Build();
 
         // Act
         var user = context.BuildUser();
 
         // Assert
-        Assert.Equal(value, user.Identifier);
+        Assert.Equal("<n/a>", user.Identifier);
+        Assert.Equal("test1", user.Custom["ID2"]);
+        Assert.Equal("test2", user.Custom["IdentifierKey"]);
+        Assert.False(user.Custom.ContainsKey("Identifier"));
     }
 
     [Fact]
-    public void UserBuilder_Should_Map_Email()
+    public void UserBuilder_Should_Map_Identifiers_With_TargetingKey_Taking_Precendence()
     {
         // Arrange
-        var context = EvaluationContext.Builder().Set("email", "email@email.com").Build();
+        var context = EvaluationContext.Builder()
+            .Set("id", "test2")
+            .Set("Identifier", "test3")
+            .SetTargetingKey("test")
+            .Build();
+
+        // Act
+        var user = context.BuildUser();
+
+        // Assert
+        Assert.Equal("test", user.Identifier);
+        Assert.Equal("test", user.Custom["targetingKey"]);
+        Assert.Equal("test2", user.Custom["id"]);
+        Assert.False(user.Custom.ContainsKey("Identifier"));
+    }
+
+    [Theory]
+    [InlineData("targetingKey")]
+    [InlineData("id")]
+    [InlineData("ID")]
+    [InlineData("identifier")]
+    [InlineData("Identifier")]
+    public void UserBuilder_Should_Map_Identifiers(string key)
+    {
+        // Arrange
+        var context = EvaluationContext.Builder().Set(key, "test").Build();
+
+        // Act
+        var user = context.BuildUser();
+
+        // Assert
+        Assert.Equal("test", user.Identifier);
+
+        if (key == nameof(user.Identifier))
+        {
+            Assert.False(user.Custom.ContainsKey(key));
+        }
+        else
+        {
+            Assert.Equal("test", user.Custom[key]);
+        }
+    }
+
+    [Theory]
+    [InlineData("email")]
+    [InlineData("Email")]
+    [InlineData("EMAIL")]
+    public void UserBuilder_Should_Map_Email(string key)
+    {
+        // Arrange
+        var context = EvaluationContext.Builder().Set(key, "email@email.com").Build();
 
         // Act
         var user = context.BuildUser();
 
         // Assert
         Assert.Equal("email@email.com", user.Email);
+
+        if (key == nameof(user.Email))
+        {
+            Assert.False(user.Custom.ContainsKey(key));
+        }
+        else
+        {
+            Assert.Equal("email@email.com", user.Custom[key]);
+        }
     }
 
-    [Fact]
-    public void UserBuilder_Should_Map_Country()
+    [Theory]
+    [InlineData("country")]
+    [InlineData("Country")]
+    [InlineData("COUNTRY")]
+    public void UserBuilder_Should_Map_Country(string key)
     {
         // Arrange
-        var context = EvaluationContext.Builder().Set("country", "US").Build();
+        var context = EvaluationContext.Builder().Set(key, "US").Build();
 
         // Act
         var user = context.BuildUser();
 
         // Assert
         Assert.Equal("US", user.Country);
+
+        if (key == nameof(user.Country))
+        {
+            Assert.False(user.Custom.ContainsKey(key));
+        }
+        else
+        {
+            Assert.Equal("US", user.Custom[key]);
+        }
     }
 
     [Fact]
     public void UserBuilder_Should_Map_Custom()
     {
         // Arrange
-        var context = EvaluationContext.Builder().Set("custom", "custom").Build();
+        var context = EvaluationContext.Builder()
+            .Set("custom", "str")
+            .Set("bool", true)
+            .Set("num", 3.14)
+            .Build();
 
         // Act
         var user = context.BuildUser();
 
         // Assert
-        Assert.Equal("custom", user.Custom["custom"]);
+        Assert.Equal("str", user.Custom["custom"]);
+        Assert.Equal(true, user.Custom["bool"]);
+        Assert.Equal(3.14, user.Custom["num"]);
     }
 }


### PR DESCRIPTION
## This PR
Updates ConfigCat providers to use the [latest ConfigCat SDK for .NET](https://github.com/configcat/.net-sdk/releases/tag/v10.0.0).

Also, 
- updates the project to use [nullable reference types](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/null-safety/nullable-reference-types),
- improves the evaluation context to user object mapping to bring the behavior closer to other ConfigCat OpenFeature providers. This comes with some breaking changes though:
  - If `targetingKey` is specified, that will be used as the identifier user attribute, instead of `id` or `identifier`.
  - If `email` or `country` occurs in multiple cases - e.g. `email` and `Email` - the first non-null occurrence will be mapped to the corresponding user attribute, instead of the last occurrence.
  - All context entries except for the ones with the exact key `Identifier`, `Email` and `Country` will also be included in the custom user attributes.
  - Entries with non-string values are now also mapped as custom attributes, rather than string-valued entries only.

### Follow-up Tasks

The PR introduces significant breaking changes, so it should be released with an increased major version.
