### PR TITLE
fix(ci): unbreak the build and e2e jobs on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - name
+      - main
     paths-ignore:
       - "**.md"
   pull_request:

--- a/test/OpenFeature.Contrib.Providers.ConfigCat.Test/ConfigCatProviderTest.cs
+++ b/test/OpenFeature.Contrib.Providers.ConfigCat.Test/ConfigCatProviderTest.cs
@@ -156,7 +156,14 @@ public class ConfigCatProviderTest
     public async Task OpenFeatureAPI_EndToEnd_Test(string email, bool expectedValue)
     {
         var configCatProvider = new ConfigCatProvider("fake-67890123456789012/1234567890123456789012", options =>
-            { options.ConfigFetcher = new FakeConfigFetcher(TestConfigJson); });
+        {
+            options.ConfigFetcher = new FakeConfigFetcher(TestConfigJson);
+            // The default AutoPoll mode gives up waiting for the initial config after 5 seconds,
+            // which a loaded CI agent can exceed even with the in-memory fetcher above. When that
+            // happens the client reports ConfigJsonNotAvailable and the assertions below see
+            // ErrorType.ProviderNotReady instead of ErrorType.None.
+            options.PollingMode = PollingModes.AutoPoll(maxInitWaitTime: TimeSpan.FromSeconds(30));
+        });
 
         await Api.Instance.SetProviderAsync(configCatProvider);
 

--- a/test/OpenFeature.Providers.Flagd.E2e.ProcessTest/BeforeHooks.cs
+++ b/test/OpenFeature.Providers.Flagd.E2e.ProcessTest/BeforeHooks.cs
@@ -26,5 +26,8 @@ public class BeforeHooks
         var tags = new HashSet<string>(scenarioTags.Concat(featureTags));
         Skip.If(!tags.Contains("in-process"), "Skipping scenario because it does not have required tag.");
         Skip.If(tags.Contains("fractional-v1"), "Skipping legacy fractional bucketing test; v2 algorithm is implemented.");
+        // TODO: remove once the CBOR-based fractional hashing from the flagd
+        // "fractional-non-string-rand-units" ADR is implemented (see open-feature/dotnet-sdk-contrib#516).
+        Skip.If(tags.Contains("fractional-v3"), "Skipping fractional v3 (CBOR-encoded hashing input) test; v2 algorithm is implemented.");
     }
 }

--- a/test/OpenFeature.Providers.Flagd.E2e.RpcTest/BeforeHooks.cs
+++ b/test/OpenFeature.Providers.Flagd.E2e.RpcTest/BeforeHooks.cs
@@ -26,5 +26,8 @@ public class BeforeHooks
         var tags = new HashSet<string>(scenarioTags.Concat(featureTags));
         Skip.If(!tags.Contains("rpc"), "Skipping scenario because it does not have required tag.");
         Skip.If(tags.Contains("fractional-v1"), "Skipping legacy fractional bucketing test; v2 algorithm is implemented.");
+        // TODO: remove once the CBOR-based fractional hashing from the flagd
+        // "fractional-non-string-rand-units" ADR is implemented (see open-feature/dotnet-sdk-contrib#516).
+        Skip.If(tags.Contains("fractional-v3"), "Skipping fractional v3 (CBOR-encoded hashing input) test; v2 algorithm is implemented.");
     }
 }


### PR DESCRIPTION
Two CI jobs are red on `main`: `e2e` and `build (windows-latest)`. They have separate, unrelated causes. This PR fixes both, plus a workflow trigger typo found along the way.

## `e2e`: new flagd conformance scenarios for an unimplemented spec revision

#716 bumped the `flagd-testbed` submodule to v3.9.0, which introduced `@fractional-v3` scenarios implementing the flagd [fractional-non-string-rand-units ADR](https://github.com/open-feature/flagd/blob/main/docs/architecture-decisions/fractional-non-string-rand-units.md). Under v3 the murmur3 input is an RFC 8949 CBOR encoding of the hashing value instead of the raw string, so every bucket assignment changes, including for plain strings. The seed and the `(hash * totalWeight) >> 32` bucket formula are unchanged.

Nobody implements v3 yet, including flagd itself (v0.16.x still calls `murmur3.StringSum32`). The testbed release explicitly treats these scenarios as opt-in:

> The new scenarios are isolated under the `@fractional-v3` tag. Existing SDK implementations ... will not fail in CI as long as their test runners filter out `v3` during the transition period.

The hooks already filtered `@fractional-v1` but not `v3`, so all 132 new scenarios ran against the v2 implementation and 115 of them failed. This adds the missing `Skip.If` to both the in-process and RPC hooks, with a TODO pointing at #516, which tracks actually implementing v3.

## `build (windows-latest)`: ConfigCat readiness timeout, not a race

`ConfigCatProviderTest.OpenFeatureAPI_EndToEnd_Test` intermittently asserted `ProviderNotReady` instead of `None`, and took 11s versus ~100ms locally.

`ConfigCatProvider.InitializeAsync` awaits `IConfigCatClient.WaitForReadyAsync()`. The default polling mode is `AutoPoll`, whose `maxInitWaitTime` default is 5 seconds. On timeout it does not throw, it returns `NoFlagData`, so initialization looks like it succeeded and the failure only surfaces on the next evaluation as `ConfigJsonNotAvailable`, which the provider maps to `ErrorType.ProviderNotReady`. That indirection is why the symptom looks unrelated to the cause.

The in-memory `FakeConfigFetcher` does not make this impossible: the initial fetch still runs as a scheduled task, and a loaded agent running several test projects and TFMs at once can miss the 5 second budget. This was confirmed with a standalone probe using a deliberately slow fetcher:

```
AutoPoll(default 5s)       readyState=NoFlagData          readyMs=5002  error=ConfigJsonNotAvailable
AutoPoll(maxInitWait 30s)  readyState=HasUpToDateFlagData readyMs=8052  error=None
LazyLoad                   readyState=NoFlagData          readyMs=0     error=None
ManualPoll                 readyState=NoFlagData          readyMs=0     error=ConfigJsonNotAvailable
```

Fix is to raise `maxInitWaitTime` to 30 seconds. `LazyLoad` also makes the symptom disappear, but for the wrong reason: it has no init wait at all, so the test would keep passing even if initialization were genuinely broken. Keeping `AutoPoll` preserves the assertion that the provider really is ready after `InitializeAsync`, just without a dependency on agent scheduling latency.

## Drive-by: CI never ran on pushes to `main`

`ci.yml` has filtered the push trigger on a branch literally named `name` since #409, so the only coverage has come from `pull_request` and `merge_group` events. Corrected to `main`.

## Verification

Run locally against Docker-backed testbed containers:

| Suite | Result |
| --- | --- |
| flagd E2E in-process (net9.0) | 174 passed, 0 failed, 217 skipped |
| flagd E2E RPC (net9.0) | 166 passed, 0 failed, 220 skipped |
| ConfigCat (net8.0 and net9.0) | 23/23 each |
| Full solution `dotnet test` | green |

## Worth a careful look

Skipping tests can hide regressions, so I reconciled the counts rather than trusting the green run. On the fractional subset, failures went from 115 to 0 but passes also went from 48 to 39. Those 9 are v3 scenarios that happened to pass because v2 and v3 agree on those particular inputs; their passing was coincidental, not evidence that v3 works. Parsing the generated Gherkin pickle metadata confirmed every newly skipped scenario carries the `@fractional-v3` tag and nothing else was silently disabled.

One pre-existing issue I did not touch, since it is out of scope but adjacent: `OpenFeatureAPI_EndToEnd_Test` calls `Api.Instance.ShutdownAsync()` without a `try/finally`, and `ConfigCatClient.Get` caches clients per SDK key while ignoring the options delegate for an already-cached key. Both theory rows share one hardcoded key, so a throwing first row could leak a misconfigured cached client into the second. Happy to fix separately if you want.

Related to #516.